### PR TITLE
Add marker components to each bone

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,12 @@ serde_json = "1"
 anyhow = "1"
 bitflags = { version = "2.9" }
 nonmax = "0.5"
+paste = "1"
 
 [dev-dependencies]
 bevy = { version = "0.16.0" }
 bevy_panorbit_camera = "0.26.0"
+bevy-inspector-egui = "0.31.0"
 
 [lints.clippy]
 type_complexity = "allow"
@@ -41,6 +43,7 @@ semicolon_if_nothing_returned = "warn"
 [features]
 default = []
 reflect = ["bevy/serialize"]
+serde = ["bevy/serialize"]
 develop = []
 
 #[lints.rust]

--- a/examples/look_at_target.rs
+++ b/examples/look_at_target.rs
@@ -38,7 +38,7 @@ fn spawn_vrm(
             MeshMaterial3d(
                 materials.add(StandardMaterial::from_color(Color::linear_rgb(1., 0., 0.))),
             ),
-            Transform::from_xyz(0.5, 2., 1.),
+            Transform::from_xyz(0.5, 1., 1.),
         ))
         .observe(apply_drag_move_cube)
         .id();

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -77,12 +77,37 @@ macro_rules! marker_component {
                 PartialEq,
                 Hash,
                 Reflect,
-                Serialize,
-                Deserialize,
+                serde::Serialize,
+                serde::Deserialize,
             )]
             #[reflect(Component, Serialize, Deserialize, Default)]
             pub struct $name;
         };
     }
 
+macro_rules! entity_component {
+        (
+            $(#[$meta:meta])*
+            $name: ident
+        ) => {
+            $(#[$meta])*
+            #[derive(
+                Component,
+                Debug,
+                Copy,
+                Clone,
+                Eq,
+                PartialEq,
+                Hash,
+                Reflect,
+                bevy::prelude::Deref,
+            )]
+            #[reflect(Component)]
+            #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+            #[cfg_attr(feature = "serde", reflect(Serialize, Deserialize))]
+            pub struct $name(pub bevy::prelude::Entity);
+        };
+    }
+
 pub(crate) use marker_component;
+pub(crate) use entity_component;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -109,5 +109,5 @@ macro_rules! entity_component {
         };
     }
 
-pub(crate) use marker_component;
 pub(crate) use entity_component;
+pub(crate) use marker_component;

--- a/src/vrm.rs
+++ b/src/vrm.rs
@@ -24,11 +24,15 @@ use std::path::PathBuf;
 pub mod prelude {
     pub use crate::vrm::{
         gltf::prelude::*,
-        humanoid_bone::*,
+        humanoid_bone::prelude::*,
         loader::{VrmAsset, VrmHandle},
         look_at::LookAt,
         mtoon::prelude::*,
-        Head, LeftEye, RightEye, Vrm, VrmHipsBoneTo, VrmPath, VrmPlugin,
+        Vrm,
+        VrmPath,
+        BoneRestTransform,
+        BoneRestGlobalTransform,
+        VrmPlugin,
     };
 }
 
@@ -73,29 +77,6 @@ pub struct BoneRestTransform(pub Transform);
 #[cfg_attr(feature = "reflect", reflect(Component, Serialize, Deserialize))]
 pub struct BoneRestGlobalTransform(pub GlobalTransform);
 
-/// Holds the entity of the hips bone.
-#[derive(Debug, Copy, Clone, Component, Deref)]
-#[cfg_attr(feature = "reflect", derive(Reflect, Serialize, Deserialize))]
-#[cfg_attr(feature = "reflect", reflect(Component, Serialize, Deserialize))]
-pub struct VrmHipsBoneTo(pub Entity);
-
-/// A marker components for left eye bone.
-#[derive(Debug, Copy, Clone, Component)]
-#[cfg_attr(feature = "reflect", derive(Reflect, Serialize, Deserialize))]
-#[cfg_attr(feature = "reflect", reflect(Component, Serialize, Deserialize))]
-pub struct LeftEye(pub Entity);
-
-/// A marker components for right eye bone.
-#[derive(Debug, Copy, Clone, Component)]
-#[cfg_attr(feature = "reflect", derive(Reflect, Serialize, Deserialize))]
-#[cfg_attr(feature = "reflect", reflect(Component, Serialize, Deserialize))]
-pub struct RightEye(pub Entity);
-
-/// Holds the entity of the vrm head bone.
-#[derive(Debug, Copy, Clone, Component)]
-#[cfg_attr(feature = "reflect", derive(Reflect, Serialize, Deserialize))]
-#[cfg_attr(feature = "reflect", reflect(Component, Serialize, Deserialize))]
-pub struct Head(pub Entity);
 
 pub struct VrmPlugin;
 
@@ -120,11 +101,7 @@ impl Plugin for VrmPlugin {
                 .register_type::<VrmPath>()
                 .register_type::<BoneRestTransform>()
                 .register_type::<BoneRestGlobalTransform>()
-                .register_type::<VrmHipsBoneTo>()
-                .register_type::<VrmBone>()
-                .register_type::<LeftEye>()
-                .register_type::<RightEye>()
-                .register_type::<Head>();
+                .register_type::<VrmBone>();
         }
     }
 }

--- a/src/vrm.rs
+++ b/src/vrm.rs
@@ -28,11 +28,7 @@ pub mod prelude {
         loader::{VrmAsset, VrmHandle},
         look_at::LookAt,
         mtoon::prelude::*,
-        Vrm,
-        VrmPath,
-        BoneRestTransform,
-        BoneRestGlobalTransform,
-        VrmPlugin,
+        BoneRestGlobalTransform, BoneRestTransform, Vrm, VrmPath, VrmPlugin,
     };
 }
 
@@ -76,7 +72,6 @@ pub struct BoneRestTransform(pub Transform);
 #[cfg_attr(feature = "reflect", derive(Reflect, Serialize, Deserialize))]
 #[cfg_attr(feature = "reflect", reflect(Component, Serialize, Deserialize))]
 pub struct BoneRestGlobalTransform(pub GlobalTransform);
-
 
 pub struct VrmPlugin;
 

--- a/src/vrm.rs
+++ b/src/vrm.rs
@@ -45,11 +45,13 @@ new_type!(
 );
 
 /// A marker component attached to the entity of VRM.
+/// This component is automatically inserted after the [`VrmHandle`](crate::prelude::VrmHandle) is loaded.
 #[derive(Debug, Component, Reflect, Copy, Clone, Serialize, Deserialize)]
 #[reflect(Component, Serialize, Deserialize)]
 pub struct Vrm;
 
 /// The path to the VRM file.
+/// This component is automatically inserted after the [`VrmHandle`](crate::prelude::VrmHandle) is loaded.
 #[derive(Debug, Reflect, Clone, Component, Serialize, Deserialize)]
 #[reflect(Component, Serialize, Deserialize)]
 pub struct VrmPath(pub PathBuf);
@@ -73,6 +75,9 @@ pub struct BoneRestTransform(pub Transform);
 #[cfg_attr(feature = "reflect", reflect(Component, Serialize, Deserialize))]
 pub struct BoneRestGlobalTransform(pub GlobalTransform);
 
+/// The main plugin for VRM support in Bevy.
+///
+/// Please refer to [`VrmHandle`](crate::prelude::VrmHandle) for more details.
 pub struct VrmPlugin;
 
 impl Plugin for VrmPlugin {

--- a/src/vrm/humanoid_bone.rs
+++ b/src/vrm/humanoid_bone.rs
@@ -1,3 +1,12 @@
+//! This module handles humanoid bones.
+//! Refer to [here](https://docs.unity3d.com/ja/2019.4/ScriptReference/HumanBodyBones.html) for the list of humanoid bones.
+//!
+//! After the VRM(A) is loaded, marker components are inserted for each bone.
+//! For example, the entity of the hips bone will have [`Hips`] inserted.
+//! Additionally, a component that holds the entity will be inserted into the VRM(A) entity.
+//!
+//! The setup of these is done after all bones have been spawned, so there may be a slight delay.
+
 mod bones;
 
 use crate::prelude::*;

--- a/src/vrm/humanoid_bone.rs
+++ b/src/vrm/humanoid_bone.rs
@@ -1,18 +1,16 @@
 mod bones;
 
+use crate::prelude::*;
 use crate::system_param::child_searcher::ChildSearcher;
 use crate::vrm::gltf::extensions::VrmNode;
-use crate::vrm::{
-    BoneRestGlobalTransform, BoneRestTransform, VrmBone,
-};
+use crate::vrm::humanoid_bone::bones::BonesPlugin;
+use crate::vrm::{BoneRestGlobalTransform, BoneRestTransform, VrmBone};
 use bevy::app::{App, Plugin, Update};
 use bevy::asset::{Assets, Handle};
 use bevy::gltf::GltfNode;
 use bevy::platform::collections::HashMap;
 use bevy::prelude::*;
 use serde::{Deserialize, Serialize};
-use crate::vrm::humanoid_bone::bones::BonesPlugin;
-use crate::prelude::*;
 
 pub mod prelude {
     pub use crate::vrm::humanoid_bone::bones::*;
@@ -65,7 +63,7 @@ macro_rules! insert_bone {
         $bone_name: expr,
         $($bone: ident),+$(,)?
     ) => {
-       
+
         match $bone_name.0.to_uppercase(){
             $(
                 x if x == stringify!($bone).to_uppercase() => {

--- a/src/vrm/humanoid_bone/bones.rs
+++ b/src/vrm/humanoid_bone/bones.rs
@@ -1,0 +1,210 @@
+use crate::macros::{marker_component, entity_component};
+use bevy::prelude::*;
+
+macro_rules! bone_marker_component {
+    ($name: ident) => {
+        marker_component!(
+            #[doc = concat!(
+                "This marker component indicates that the entity is a `",
+                stringify!($name),
+                "` bone.\n\
+                 This is automatically inserted after the VRM or VRMA has loaded."
+            )]
+            $name
+        );
+
+        paste::paste!{
+            entity_component!(
+                #[doc = concat!(
+                "This component holds the entity of `",
+                stringify!($name),
+                "` bone.\n\
+                 This is automatically inserted into the entity of VRM or VRMA, after they have finished loading."
+                )]
+                [<$name BoneEntity>]
+            );
+        }
+    };
+
+    ($($names: ident),+ $(,)?) => {
+        $(bone_marker_component!($names);)+
+    };
+}
+
+bone_marker_component!(
+    Hips,
+    RightRingProximal,
+    RightThumbDistal,
+    RightRingIntermediate,
+    RightUpperArm,
+    LeftIndexProximal,
+    LeftUpperLeg,
+    LeftFoot,
+    LeftIndexDistal,
+    LeftThumbMetacarpal,
+    RightLowerArm,
+    LeftMiddleDistal,
+    RightUpperLeg,
+    LeftToes,
+    LeftThumbDistal,
+    RightShoulder,
+    RightThumbMetacarpal,
+    Spine,
+    LeftLowerLeg,
+    LeftShoulder,
+    LeftUpperArm,
+    UpperChest,
+    RightToes,
+    RightIndexDistal,
+    LeftMiddleProximal,
+    LeftRingProximal,
+    LeftRingDistal,
+    LeftThumbProximal,
+    LeftIndexIntermediate,
+    LeftLittleProximal,
+    LeftLittleDistal,
+    RightHand,
+    RightLittleProximal,
+    LeftRingIntermediate,
+    RightIndexIntermediate,
+    Chest,
+    LeftHand,
+    RightLittleIntermediate,
+    RightFoot,
+    RightLowerLeg,
+    LeftLittleIntermediate,
+    LeftLowerArm,
+    RightLittleDistal,
+    RightMiddleIntermediate,
+    RightMiddleProximal,
+    RightThumbProximal,
+    Neck,
+    Jaw,
+    Head,
+    LeftEye,
+    RightEye,
+    LeftMiddleIntermediate,
+    RightRingDistal,
+    RightIndexProximal,
+    RightMiddleDistal,
+);
+
+pub(super) struct BonesPlugin;
+
+impl Plugin for BonesPlugin {
+    fn build(
+        &self,
+        app: &mut App,
+    ) {
+        app.register_type::<Hips>()
+            .register_type::<RightRingProximal>()
+            .register_type::<RightThumbDistal>()
+            .register_type::<RightRingIntermediate>()
+            .register_type::<RightUpperArm>()
+            .register_type::<LeftIndexProximal>()
+            .register_type::<LeftUpperLeg>()
+            .register_type::<LeftFoot>()
+            .register_type::<LeftIndexDistal>()
+            .register_type::<LeftThumbMetacarpal>()
+            .register_type::<RightLowerArm>()
+            .register_type::<LeftMiddleDistal>()
+            .register_type::<RightUpperLeg>()
+            .register_type::<LeftToes>()
+            .register_type::<LeftThumbDistal>()
+            .register_type::<RightShoulder>()
+            .register_type::<RightThumbMetacarpal>()
+            .register_type::<Spine>()
+            .register_type::<LeftLowerLeg>()
+            .register_type::<LeftShoulder>()
+            .register_type::<LeftUpperArm>()
+            .register_type::<UpperChest>()
+            .register_type::<RightToes>()
+            .register_type::<RightIndexDistal>()
+            .register_type::<LeftMiddleProximal>()
+            .register_type::<LeftRingProximal>()
+            .register_type::<LeftRingDistal>()
+            .register_type::<LeftThumbProximal>()
+            .register_type::<LeftIndexIntermediate>()
+            .register_type::<LeftLittleProximal>()
+            .register_type::<LeftLittleDistal>()
+            .register_type::<RightHand>()
+            .register_type::<RightLittleProximal>()
+            .register_type::<LeftRingIntermediate>()
+            .register_type::<RightIndexIntermediate>()
+            .register_type::<Chest>()
+            .register_type::<LeftHand>()
+            .register_type::<RightLittleIntermediate>()
+            .register_type::<RightFoot>()
+            .register_type::<RightLowerLeg>()
+            .register_type::<LeftLittleIntermediate>()
+            .register_type::<LeftLowerArm>()
+            .register_type::<RightLittleDistal>()
+            .register_type::<RightMiddleIntermediate>()
+            .register_type::<RightMiddleProximal>()
+            .register_type::<RightThumbProximal>()
+            .register_type::<Neck>()
+            .register_type::<Jaw>()
+            .register_type::<Head>()
+            .register_type::<LeftEye>()
+            .register_type::<RightEye>()
+            .register_type::<LeftMiddleIntermediate>()
+            .register_type::<RightRingDistal>()
+            .register_type::<RightIndexProximal>()
+            .register_type::<RightMiddleDistal>()
+            .register_type::<HipsBoneEntity>()
+            .register_type::<RightRingProximalBoneEntity>()
+            .register_type::<RightThumbDistalBoneEntity>()
+            .register_type::<RightRingIntermediateBoneEntity>()
+            .register_type::<RightUpperArmBoneEntity>()
+            .register_type::<LeftIndexProximalBoneEntity>()
+            .register_type::<LeftUpperLegBoneEntity>()
+            .register_type::<LeftFootBoneEntity>()
+            .register_type::<LeftIndexDistalBoneEntity>()
+            .register_type::<LeftThumbMetacarpalBoneEntity>()
+            .register_type::<RightLowerArmBoneEntity>()
+            .register_type::<LeftMiddleDistalBoneEntity>()
+            .register_type::<RightUpperLegBoneEntity>()
+            .register_type::<LeftToesBoneEntity>()
+            .register_type::<LeftThumbDistalBoneEntity>()
+            .register_type::<RightShoulderBoneEntity>()
+            .register_type::<RightThumbMetacarpalBoneEntity>()
+            .register_type::<SpineBoneEntity>()
+            .register_type::<LeftLowerLegBoneEntity>()
+            .register_type::<LeftShoulderBoneEntity>()
+            .register_type::<LeftUpperArmBoneEntity>()
+            .register_type::<UpperChestBoneEntity>()
+            .register_type::<RightToesBoneEntity>()
+            .register_type::<RightIndexDistalBoneEntity>()
+            .register_type::<LeftMiddleProximalBoneEntity>()
+            .register_type::<LeftRingProximalBoneEntity>()
+            .register_type::<LeftRingDistalBoneEntity>()
+            .register_type::<LeftThumbProximalBoneEntity>()
+            .register_type::<LeftIndexIntermediateBoneEntity>()
+            .register_type::<LeftLittleProximalBoneEntity>()
+            .register_type::<LeftLittleDistalBoneEntity>()
+            .register_type::<RightHandBoneEntity>()
+            .register_type::<RightLittleProximalBoneEntity>()
+            .register_type::<LeftRingIntermediateBoneEntity>()
+            .register_type::<RightIndexIntermediateBoneEntity>()
+            .register_type::<ChestBoneEntity>()
+            .register_type::<LeftHandBoneEntity>()
+            .register_type::<RightLittleIntermediateBoneEntity>()
+            .register_type::<RightFootBoneEntity>()
+            .register_type::<RightLowerLegBoneEntity>()
+            .register_type::<LeftLittleIntermediateBoneEntity>()
+            .register_type::<LeftLowerArmBoneEntity>()
+            .register_type::<RightLittleDistalBoneEntity>()
+            .register_type::<RightMiddleIntermediateBoneEntity>()
+            .register_type::<RightMiddleProximalBoneEntity>()
+            .register_type::<RightThumbProximalBoneEntity>()
+            .register_type::<NeckBoneEntity>()
+            .register_type::<JawBoneEntity>()
+            .register_type::<HeadBoneEntity>()
+            .register_type::<LeftEyeBoneEntity>()
+            .register_type::<RightEyeBoneEntity>()
+            .register_type::<LeftMiddleIntermediateBoneEntity>()
+            .register_type::<RightRingDistalBoneEntity>()
+            .register_type::<RightIndexProximalBoneEntity>()
+            .register_type::<RightMiddleDistalBoneEntity>();
+    }
+}

--- a/src/vrm/humanoid_bone/bones.rs
+++ b/src/vrm/humanoid_bone/bones.rs
@@ -1,4 +1,4 @@
-use crate::macros::{marker_component, entity_component};
+use crate::macros::{entity_component, marker_component};
 use bevy::prelude::*;
 
 macro_rules! bone_marker_component {

--- a/src/vrm/loader.rs
+++ b/src/vrm/loader.rs
@@ -32,6 +32,29 @@ impl Plugin for VrmLoaderPlugin {
     }
 }
 
+/// A handle to load a VRM.
+/// This component is removed after the VRM is loaded.
+///
+/// This handle is used to load a VRM, and after it is loaded, the following components are automatically inserted:
+///
+/// - [`Vrm`](crate::prelude::Vrm)
+/// - [`VrmPath`](crate::prelude::VrmPath)
+/// - [`BoneRestTransform`](crate::prelude::BoneRestTransform)
+/// - [`BoneRestGlobalTransform`](crate::prelude::BoneRestGlobalTransform)
+/// - [`SceneRoot`](bevy::scene::SceneRoot)
+/// - Components hold the entity of each bone, refer to [here](crate::vrm::humanoid_bone) for more details.
+///
+/// ```no_run
+/// use bevy::prelude::*;
+/// use bevy_vrm1::prelude::*;
+///
+/// fn spawn_vrm(
+///     mut commands: Commands,
+///    asset_server: Res<AssetServer>,
+/// ){
+///     commands.spawn(VrmHandle(asset_server.load("<vrm>.vrm")));
+/// }
+/// ```
 #[derive(Debug, Component)]
 pub struct VrmHandle(pub Handle<VrmAsset>);
 

--- a/src/vrm/look_at.rs
+++ b/src/vrm/look_at.rs
@@ -1,8 +1,7 @@
 //! - [`look at specification(en)`](https://github.com/vrm-c/vrm-specification/blob/master/specification/VRMC_vrm-1.0/lookAt.md)
 //! - [`look at specification(ja)`](https://github.com/vrm-c/vrm-specification/blob/master/specification/VRMC_vrm-1.0/lookAt.ja.md)
 
-use crate::vrm::gltf::extensions::vrmc_vrm::{LookAtProperties, LookAtType};
-use crate::vrm::{Head, LeftEye, RightEye};
+use crate::prelude::*;
 use bevy::app::{App, Plugin};
 use bevy::prelude::*;
 use bevy::render::camera::RenderTarget;
@@ -66,7 +65,7 @@ impl Plugin for LookAtPlugin {
 
 fn track_looking_target(
     par_commands: ParallelCommands,
-    vrms: Query<(&LookAt, &LookAtProperties, &Head, &LeftEye, &RightEye)>,
+    vrms: Query<(&LookAt, &LookAtProperties, &HeadBoneEntity, &LeftEyeBoneEntity, &RightEyeBoneEntity)>,
     cameras: Query<(Entity, &Camera)>,
     transforms: Query<&Transform>,
     global_transforms: Query<&GlobalTransform>,
@@ -149,8 +148,8 @@ fn calc_target_position(
 fn apply_bone(
     par_commands: &ParallelCommands,
     transforms: &Query<&Transform>,
-    left_eye: &LeftEye,
-    right_eye: &RightEye,
+    left_eye: &LeftEyeBoneEntity,
+    right_eye: &RightEyeBoneEntity,
     properties: &LookAtProperties,
     yaw: f32,
     pitch: f32,

--- a/src/vrm/look_at.rs
+++ b/src/vrm/look_at.rs
@@ -65,7 +65,13 @@ impl Plugin for LookAtPlugin {
 
 fn track_looking_target(
     par_commands: ParallelCommands,
-    vrms: Query<(&LookAt, &LookAtProperties, &HeadBoneEntity, &LeftEyeBoneEntity, &RightEyeBoneEntity)>,
+    vrms: Query<(
+        &LookAt,
+        &LookAtProperties,
+        &HeadBoneEntity,
+        &LeftEyeBoneEntity,
+        &RightEyeBoneEntity,
+    )>,
     cameras: Query<(Entity, &Camera)>,
     transforms: Query<&Transform>,
     global_transforms: Query<&GlobalTransform>,

--- a/src/vrm/spring_bone/setup.rs
+++ b/src/vrm/spring_bone/setup.rs
@@ -9,7 +9,6 @@ use crate::vrm::spring_bone::{
 };
 use bevy::app::{App, Update};
 use bevy::prelude::*;
-use serde::{Deserialize, Serialize};
 
 pub struct SpringBoneSetupPlugin;
 

--- a/src/vrma.rs
+++ b/src/vrma.rs
@@ -52,6 +52,16 @@ impl Plugin for VrmaPlugin {
 }
 
 /// An asset handle to spawn VRMA.
+///
+/// After this handle is loaded, the following components are inserted. Then this handle is removed.
+///
+/// - [`Vrma`]
+/// - [`VrmaPath`]
+/// - [`VrmaDuration`]
+/// - [`BoneRestTransform`](crate::prelude::BoneRestTransform)
+/// - [`BoneRestGlobalTransform`](crate::prelude::BoneRestGlobalTransform)
+/// - [`SceneRoot`](bevy::scene::SceneRoot)
+/// - Components hold the entity of each bone, refer to [here](crate::vrm::humanoid_bone) for more details.
 #[derive(Debug, Component)]
 #[cfg_attr(feature = "reflect", derive(Reflect))]
 #[cfg_attr(feature = "reflect", reflect(Component))]

--- a/src/vrma/retarget/bone.rs
+++ b/src/vrma/retarget/bone.rs
@@ -2,12 +2,11 @@
 
 use crate::macros::marker_component;
 use crate::system_param::child_searcher::ChildSearcher;
-use crate::vrm::humanoid_bone::{Hips, HumanoidBoneRegistry, HumanoidBonesAttached};
-use crate::vrm::{BoneRestGlobalTransform, BoneRestTransform, VrmHipsBoneTo};
+use crate::vrm::humanoid_bone::{ HumanoidBoneRegistry, HumanoidBonesAttached};
 use crate::vrma::retarget::{CurrentRetargeting, RetargetBindingSystemSet};
 use crate::vrma::{RetargetSource, RetargetTo};
+use crate::prelude::*;
 use bevy::prelude::*;
-use serde::{Deserialize, Serialize};
 
 pub(super) struct VrmaRetargetingBonePlugin;
 
@@ -40,7 +39,7 @@ fn retarget_bones_to_vrm(
         (Entity, &RetargetTo, &HumanoidBoneRegistry),
         (Without<RetargetedHumanBones>, With<HumanoidBonesAttached>),
     >,
-    hips: Query<&VrmHipsBoneTo>,
+    hips: Query<&HipsBoneEntity>,
     names: Query<&Name>,
     searcher: ChildSearcher,
 ) {
@@ -151,10 +150,10 @@ fn calc_hips_position(
 mod tests {
     use crate::tests::{test_app, TestResult};
     use crate::vrm::humanoid_bone::{HumanoidBoneRegistry, HumanoidBonesAttached};
-    use crate::vrm::VrmHipsBoneTo;
     use crate::vrma::retarget::bone::{
         calc_delta, calc_scaling, retarget_bones_to_vrm, RetargetedHumanBones,
     };
+    use crate::prelude::*;
     use crate::vrma::RetargetTo;
     use bevy::ecs::system::RunSystemOnce;
     use bevy::math::Vec3;
@@ -176,7 +175,7 @@ mod tests {
     fn has_been_attached_humanoid_bones() -> TestResult {
         let mut app = test_app();
         app.world_mut().run_system_once(|mut commands: Commands| {
-            let vrm = commands.spawn(VrmHipsBoneTo(Entity::PLACEHOLDER)).id();
+            let vrm = commands.spawn(HipsBoneEntity(Entity::PLACEHOLDER)).id();
             commands.spawn((
                 HumanoidBoneRegistry::default(),
                 RetargetTo(vrm),

--- a/src/vrma/retarget/bone.rs
+++ b/src/vrma/retarget/bone.rs
@@ -1,11 +1,11 @@
 //! This module retargets VRMA bones to the parent VRM.
 
 use crate::macros::marker_component;
+use crate::prelude::*;
 use crate::system_param::child_searcher::ChildSearcher;
-use crate::vrm::humanoid_bone::{ HumanoidBoneRegistry, HumanoidBonesAttached};
+use crate::vrm::humanoid_bone::{HumanoidBoneRegistry, HumanoidBonesAttached};
 use crate::vrma::retarget::{CurrentRetargeting, RetargetBindingSystemSet};
 use crate::vrma::{RetargetSource, RetargetTo};
-use crate::prelude::*;
 use bevy::prelude::*;
 
 pub(super) struct VrmaRetargetingBonePlugin;
@@ -148,12 +148,12 @@ fn calc_hips_position(
 
 #[cfg(test)]
 mod tests {
+    use crate::prelude::*;
     use crate::tests::{test_app, TestResult};
     use crate::vrm::humanoid_bone::{HumanoidBoneRegistry, HumanoidBonesAttached};
     use crate::vrma::retarget::bone::{
         calc_delta, calc_scaling, retarget_bones_to_vrm, RetargetedHumanBones,
     };
-    use crate::prelude::*;
     use crate::vrma::RetargetTo;
     use bevy::ecs::system::RunSystemOnce;
     use bevy::math::Vec3;


### PR DESCRIPTION
 After the VRM(A) is loaded, marker components are inserted for each bone.
For example, the entity of the hips bone will have [`Hips`] inserted.

Additionally, a component that holds the entity will be inserted into the VRM(A) entity.
Component names follow the pattern `<BoneName>BoneEntity`.
