### PR TITLE
Fix collider unit error

### DIFF
--- a/src/vrm/gltf/extensions/vrmc_spring_bone.rs
+++ b/src/vrm/gltf/extensions/vrmc_spring_bone.rs
@@ -118,7 +118,8 @@ impl ColliderShape {
                 let translation = collider.transform_point(Vec3::from(sphere.offset));
                 let r = joint_radius + sphere.radius * max_collider_scale;
                 let delta = *next_tail - translation;
-                if delta.length() <= r * r {
+                let distance_squared = delta.length_squared();
+                if distance_squared > 0.0 && distance_squared <= r * r {
                     let dir = delta.normalize();
                     let pos_from_collider = translation + dir * r;
                     *next_tail = head_global_pos

--- a/src/vrm/mtoon_fragment.wgsl
+++ b/src/vrm/mtoon_fragment.wgsl
@@ -152,7 +152,7 @@ fn apply_directional_lights(in: MToonInput) -> vec3<f32>{
     var shade_color: vec3<f32> = calc_shade_color(in);
     var shading: f32 = 0.0;
     for (var i: u32 = 0u; i < lights.n_directional_lights; i = i + 1u) {
-        if (lights.directional_lights[i].skip != 0u || (lights.directional_lights[i].flags & DIRECTIONAL_LIGHT_FLAGS_SHADOWS_ENABLED_BIT) == 0u) {
+        if (lights.directional_lights[i].flags & DIRECTIONAL_LIGHT_FLAGS_SHADOWS_ENABLED_BIT) == 0u {
             continue;
         }
         shading += calc_mtoon_lighting_shading(in, i);


### PR DESCRIPTION
Hello again.

I noticed a collider error.

How I noticed?
This is how it looked like and it was clear for me that there is some kind of error inside the collider logic:
![image](https://github.com/user-attachments/assets/23ef40e3-f048-45ce-8f21-044aec313242)

And there was. Here it is comparing x with x^2, which essentially is just a unit error:
```rust
                let delta = *next_tail - translation;
                if delta.length() <= r * r {
                    let dir = delta.normalize();
```

One could do this and it would work just fine:
```rust
                let delta = *next_tail - translation;
                if delta.length() <= r {
                    let dir = delta.normalize();
```

But .length does a sqrt and I read that it is CPU intensive. So my solution is to square it and compare it with r * r:
```rust
                let delta = *next_tail - translation;
                if delta.length_squared() <= r * r {
                    let dir = delta.normalize();
```

And then I saw delta.normalize doing a division and to avoid 0 division errors I think you also have to check it like this:
```rust
                let delta = *next_tail - translation;
                let distance_squared = delta.length_squared();
                if distance_squared > 0.0 && distance_squared <= r * r {
                    let dir = delta.normalize();
```

Anyway, now it looks like this:
![image](https://github.com/user-attachments/assets/cc93afb0-1793-4556-8ad6-81fc6d334377)
