### PR TITLE
Fix ColliderGroup::name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 - Fixed collision detection for the SpringBone sphere collider.
 - Fixed logic to determine redraw
+- Fixed look at bone rotation
+- Fixed `ColliderGroup::name` types from `String` to `Option<String>` to match the spec.
 
 ## v0.2.2
 

--- a/src/vrm/gltf/extensions/vrmc_spring_bone.rs
+++ b/src/vrm/gltf/extensions/vrmc_spring_bone.rs
@@ -41,7 +41,7 @@ impl VRMCSpringBone {
 #[derive(Serialize, Deserialize)]
 pub struct ColliderGroup {
     /// Group name
-    pub name: String,
+    pub name: Option<String>,
 
     /// The list of colliders belonging to this group.
     /// Each value is an index of `VRMCSpringBone::colliders`.


### PR DESCRIPTION
Fixed `ColliderGroup::name` types from `String` to `Option<String>` to match the spec.