### PR TITLE
Remove cursor fallback log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v0.6.3
+
+[Release Notes](https://github.com/not-elm/bevy_vrm1/releases/tag/v0.6.3)
+
+### Others
+
+- Removed unnecessary cursor position fallback log output
+
 ## v0.6.2
 
 [Release Notes](https://github.com/not-elm/bevy_vrm1/releases/tag/v0.6.2)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_vrm1"
-version = "0.6.2"
+version = "0.6.3-dev"
 edition = "2024"
 authors = ["notelm <elmprograminfo@gmail.com>"]
 description = "Allows you to use VRM and VRMA in Bevy"

--- a/src/vrm/look_at.rs
+++ b/src/vrm/look_at.rs
@@ -179,18 +179,6 @@ pub(crate) fn find_cursor_world_position(
         #[cfg(target_os = "windows")]
         let cursor = {
             let fallback = fallback_cursor_position(window);
-
-            #[cfg(debug_assertions)]
-            if let (Some(c), Some(f)) = (cursor, fallback)
-                && c.distance(f) > 1.0
-            {
-                #[cfg(feature = "log")]
-                bevy::log::warn!(
-                    "Cursor position mismatch: bevy={c}, winapi={f}, delta={}",
-                    c.distance(f)
-                );
-            }
-
             cursor.or(fallback)
         };
 


### PR DESCRIPTION
## Summary

- Removed unnecessary cursor position fallback log output that was left from debugging
- Added v0.6.3 changelog entry and bumped version to 0.6.3-dev

## Test plan

- [ ] Verify cursor tracking still works correctly on Windows
- [ ] Confirm no log output for cursor fallback path

🤖 Generated with [Claude Code](https://claude.com/claude-code)