### PR TITLE
fix: redesign VRMA retargeting to fix multi-VRM animation stop bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## v0.7.0
+
+### Breaking Changes
+
+- Redesigned VRMA retargeting: replaced custom `AnimationCurve` wrappers with pre-baked clips that apply retarget transformations at initialization time
+
+### Bug Fixes
+
+- Fixed multi-VRM animation stop bug: spawning 2+ VRMs from the same `.vrm` file no longer causes animations to stop
+- Fixed animation transition interpolation for VRMs with different initial poses (Issue #32)
+
 ## v0.6.4
 
 [Release Notes](https://github.com/not-elm/bevy_vrm1/releases/tag/v0.6.4)

--- a/src/vrm/initialize.rs
+++ b/src/vrm/initialize.rs
@@ -33,6 +33,8 @@ fn spawn_vrm(
     mut commands: Commands,
     node_assets: Res<Assets<GltfNode>>,
     vrm_assets: Res<Assets<VrmAsset>>,
+    mut scene_assets: ResMut<Assets<Scene>>,
+    type_registry: Res<AppTypeRegistry>,
     handles: Query<(Entity, &VrmHandle)>,
 ) {
     for (vrm_handle_entity, handle) in handles.iter() {
@@ -41,9 +43,21 @@ fn spawn_vrm(
         };
         commands.entity(vrm_handle_entity).remove::<VrmHandle>();
 
-        let Some(scene) = vrm.gltf.scenes.first() else {
+        let Some(scene_handle) = vrm.gltf.scenes.first() else {
             continue;
         };
+        // Clone the Scene asset to give each VRM instance its own independent copy.
+        // Without this, Bevy's SceneSpawner groups all instances sharing the same
+        // Scene AssetId and respawns them together on AssetEvent::Modified, which
+        // destroys custom components (Name, VrmBone, AnimationPlayer, etc.) that
+        // were inserted during initialization.
+        let Some(source_scene) = scene_assets.get(scene_handle) else {
+            continue;
+        };
+        let Ok(cloned_scene) = source_scene.clone_with(&type_registry) else {
+            continue;
+        };
+        let scene = scene_assets.add(cloned_scene);
         let extensions = match VrmExtensions::from_gltf(&vrm.gltf) {
             Ok(extensions) => extensions,
             Err(e) => {
@@ -55,7 +69,7 @@ fn spawn_vrm(
         cmd.insert((
             Vrm,
             Name::new(extensions.name().unwrap_or_else(|| "VRM".to_string())),
-            SceneRoot(scene.clone()),
+            SceneRoot(scene),
             VrmcMaterialRegistry::new(&vrm.gltf, vrm.images.clone()),
             VrmExpressionRegistry::new(&extensions, &node_assets, &vrm.gltf.nodes),
             HumanoidBoneRegistry::new(
@@ -113,12 +127,9 @@ fn request_initialize(
             .trigger(RequestInitializeSpringBone)
             .trigger(RequestInitializeNodeConstraints);
         if has_vrma {
-            if let Ok(ChildOf(vrm)) = parents.get(root) {
-                commands.trigger(RequestUpdateAnimationGraph {
-                    vrma: root,
-                    vrm: *vrm,
-                });
-            };
+            // RequestUpdateAnimationGraph is now triggered from trigger_loaded
+            // (vrma/initialize.rs) after Added<Initialized> is detected, ensuring
+            // VrmBone components from RequestInitializeHumanoidBones are applied.
         } else {
             commands.entity(root).trigger(RequestInitializeExpressions);
         }

--- a/src/vrma/animation.rs
+++ b/src/vrma/animation.rs
@@ -1,4 +1,5 @@
 pub(crate) mod animation_graph;
+pub(crate) mod bake;
 mod bone_rotation;
 mod bone_translation;
 pub(crate) mod expressions;

--- a/src/vrma/animation/animation_graph.rs
+++ b/src/vrma/animation/animation_graph.rs
@@ -158,17 +158,8 @@ fn apply_replace_humanoid_bone_animation_clips(
     let Some(root_bone) = searcher.find_root_bone(*vrm_entity) else {
         return;
     };
-
-    // Clone the clip to prevent shared-asset mutation (fixes multi-VRM stop bug)
-    let Some(source_clip) = clips.get(vrm_animation_clip_handle.0.id()).cloned() else {
-        return;
-    };
-    let new_handle = clips.add(source_clip);
-    commands
-        .entity(vrma_entity)
-        .insert(VrmAnimationClipHandle(new_handle.clone()));
-
-    let Some(clip) = clips.get_mut(new_handle.id()) else {
+    // Note: AnimationClip is already cloned per-VRMA in initialize.rs:67-71
+    let Some(clip) = clips.get_mut(vrm_animation_clip_handle.0.id()) else {
         return;
     };
     let transformations = compute_rotation_transformations(

--- a/src/vrma/animation/animation_graph.rs
+++ b/src/vrma/animation/animation_graph.rs
@@ -2,13 +2,14 @@ use crate::prelude::{ChildSearcher, RestGlobalTransform, RestTransform};
 use crate::vrm::expressions::VrmExpressionRegistry;
 use crate::vrm::humanoid_bone::HumanoidBoneRegistry;
 use crate::vrma::animation::bone_rotation::{
-    BoneRotationAnimationCurve, register_rotate_transformation,
+    BoneRotationAnimationCurve, RetargetRotationTable, compute_rotation_transformations,
 };
 use crate::vrma::animation::bone_translation::{
     HipsTranslationAnimationCurve, register_hips_translation_transformation,
 };
 use crate::vrma::{VrmAnimationClipHandle, VrmAnimationNodeIndex};
 use bevy::animation::{AnimationTargetId, animated_field};
+use bevy::platform::collections::HashMap;
 use bevy::app::App;
 use bevy::prelude::*;
 
@@ -170,7 +171,7 @@ fn apply_replace_humanoid_bone_animation_clips(
     let Some(clip) = clips.get_mut(new_handle.id()) else {
         return;
     };
-    register_rotate_transformation(
+    let transformations = compute_rotation_transformations(
         vrma_entity,
         vrma_node_index.0,
         root_bone,
@@ -178,7 +179,20 @@ fn apply_replace_humanoid_bone_animation_clips(
         &searcher,
         &bones,
     );
+    for (bone_entity, node_index, transformation) in transformations {
+        commands
+            .entity(bone_entity)
+            .entry::<RetargetRotationTable>()
+            .and_modify(move |mut table| {
+                table.0.insert(node_index, transformation);
+            })
+            .or_insert(RetargetRotationTable(HashMap::from([(
+                node_index,
+                transformation,
+            )])));
+    }
     replace_bone_animation_clips(
+        &mut commands,
         clip,
         vrma_node_index.0,
         vrma_entity,
@@ -190,6 +204,7 @@ fn apply_replace_humanoid_bone_animation_clips(
 }
 
 fn replace_bone_animation_clips(
+    commands: &mut Commands,
     clip: &mut AnimationClip,
     node_index: AnimationNodeIndex,
     vrma_entity: Entity,

--- a/src/vrma/animation/animation_graph.rs
+++ b/src/vrma/animation/animation_graph.rs
@@ -5,7 +5,7 @@ use crate::vrma::animation::bone_rotation::{
     BoneRotationAnimationCurve, RetargetRotationTable, compute_rotation_transformations,
 };
 use crate::vrma::animation::bone_translation::{
-    HipsTranslationAnimationCurve, register_hips_translation_transformation,
+    HipsTranslationAnimationCurve, RetargetTranslationTable, compute_hips_transformation,
 };
 use crate::vrma::{VrmAnimationClipHandle, VrmAnimationNodeIndex};
 use bevy::animation::{AnimationTargetId, animated_field};
@@ -228,14 +228,22 @@ fn replace_bone_animation_clips(
             continue;
         };
         if bone.as_str() == "hips" {
-            register_hips_translation_transformation(
+            let (node_idx, hips_tf) = compute_hips_transformation(
                 node_index,
-                bone_entity,
                 src_rest_tf,
                 src_rest_gtf,
                 dist_rest_tf,
                 dist_rest_gtf,
             );
+            commands
+                .entity(bone_entity)
+                .entry::<RetargetTranslationTable>()
+                .and_modify(move |mut table| {
+                    table.0.insert(node_idx, hips_tf);
+                })
+                .or_insert(RetargetTranslationTable(HashMap::from([(
+                    node_idx, hips_tf,
+                )])));
         }
         if let Some(curves) = animation_curves.remove(vrma_bone_target) {
             let mut cs = Vec::new();

--- a/src/vrma/animation/animation_graph.rs
+++ b/src/vrma/animation/animation_graph.rs
@@ -118,7 +118,7 @@ fn insert_animation_graph_into_expressions(
     };
     for expression in expression_children.iter() {
         let Ok((has_player, previous_handle)) = expressions.get(expression) else {
-            return;
+            continue;
         };
         if let Some(previous_handle) = previous_handle {
             graphs.remove(previous_handle);
@@ -316,10 +316,10 @@ fn apply_regenerate_expression_clips(
             continue;
         };
         let Ok(vrma_target) = animation_targets.get(vrma_expression) else {
-            return;
+            continue;
         };
         let Ok(target) = animation_targets.get(expression_entity) else {
-            return;
+            continue;
         };
         let animation_curves = clip.curves_mut();
         if let Some(curves) = animation_curves.remove(vrma_target) {

--- a/src/vrma/animation/animation_graph.rs
+++ b/src/vrma/animation/animation_graph.rs
@@ -1,13 +1,17 @@
 use crate::prelude::{ChildSearcher, RestGlobalTransform, RestTransform};
 use crate::vrm::expressions::VrmExpressionRegistry;
 use crate::vrm::humanoid_bone::HumanoidBoneRegistry;
-use crate::vrma::animation::bone_rotation::{RetargetRotationTable, compute_rotation_transformations};
-use crate::vrma::animation::bone_translation::{RetargetTranslationTable, compute_hips_transformation};
-use crate::vrma::{VrmAnimationClipHandle, VrmAnimationNodeIndex};
 use crate::vrma::animation::bake::{bake_rotation_curve, bake_translation_curve};
+use crate::vrma::animation::bone_rotation::{
+    RetargetRotationTable, compute_rotation_transformations,
+};
+use crate::vrma::animation::bone_translation::{
+    RetargetTranslationTable, compute_hips_transformation,
+};
+use crate::vrma::{VrmAnimationClipHandle, VrmAnimationNodeIndex};
 use bevy::animation::{AnimationTargetId, animated_field};
-use bevy::platform::collections::HashMap;
 use bevy::app::App;
+use bevy::platform::collections::HashMap;
 use bevy::prelude::*;
 
 /// Marker: VRMA clip needs baking.
@@ -309,8 +313,7 @@ fn apply_bake_clips(world: &mut World) {
                         // Use the specific VRMA's AnimationNodeIndex to get the correct transformation
                         if let Some(table) = world.get::<RetargetRotationTable>(bone)
                             && let Some(transformation) = table.0.get(&node_index).cloned()
-                            && let Some(baked_vc) =
-                                bake_rotation_curve(vc, &transformation, world)
+                            && let Some(baked_vc) = bake_rotation_curve(vc, &transformation, world)
                         {
                             baked_curves.push(baked_vc);
                             baked = true;
@@ -318,8 +321,7 @@ fn apply_bake_clips(world: &mut World) {
                     } else if *target == translation_component
                         && let Some(table) = world.get::<RetargetTranslationTable>(bone)
                         && let Some(transformation) = table.0.get(&node_index).cloned()
-                        && let Some(baked_vc) =
-                            bake_translation_curve(vc, &transformation, world)
+                        && let Some(baked_vc) = bake_translation_curve(vc, &transformation, world)
                     {
                         baked_curves.push(baked_vc);
                         baked = true;

--- a/src/vrma/animation/animation_graph.rs
+++ b/src/vrma/animation/animation_graph.rs
@@ -132,6 +132,7 @@ fn insert_animation_graph_into_expressions(
 
 fn apply_replace_humanoid_bone_animation_clips(
     trigger: On<RequestUpdateAnimationClips>,
+    mut commands: Commands,
     mut clips: ResMut<Assets<AnimationClip>>,
     clip_handles: Query<&VrmAnimationClipHandle>,
     parents: Query<&ChildOf>,
@@ -156,7 +157,17 @@ fn apply_replace_humanoid_bone_animation_clips(
     let Some(root_bone) = searcher.find_root_bone(*vrm_entity) else {
         return;
     };
-    let Some(clip) = clips.get_mut(vrm_animation_clip_handle.0.id()) else {
+
+    // Clone the clip to prevent shared-asset mutation (fixes multi-VRM stop bug)
+    let Some(source_clip) = clips.get(vrm_animation_clip_handle.0.id()).cloned() else {
+        return;
+    };
+    let new_handle = clips.add(source_clip);
+    commands
+        .entity(vrma_entity)
+        .insert(VrmAnimationClipHandle(new_handle.clone()));
+
+    let Some(clip) = clips.get_mut(new_handle.id()) else {
         return;
     };
     register_rotate_transformation(

--- a/src/vrma/animation/animation_graph.rs
+++ b/src/vrma/animation/animation_graph.rs
@@ -1,17 +1,18 @@
 use crate::prelude::{ChildSearcher, RestGlobalTransform, RestTransform};
 use crate::vrm::expressions::VrmExpressionRegistry;
 use crate::vrm::humanoid_bone::HumanoidBoneRegistry;
-use crate::vrma::animation::bone_rotation::{
-    BoneRotationAnimationCurve, RetargetRotationTable, compute_rotation_transformations,
-};
-use crate::vrma::animation::bone_translation::{
-    HipsTranslationAnimationCurve, RetargetTranslationTable, compute_hips_transformation,
-};
+use crate::vrma::animation::bone_rotation::{RetargetRotationTable, compute_rotation_transformations};
+use crate::vrma::animation::bone_translation::{RetargetTranslationTable, compute_hips_transformation};
 use crate::vrma::{VrmAnimationClipHandle, VrmAnimationNodeIndex};
+use crate::vrma::animation::bake::{bake_rotation_curve, bake_translation_curve};
 use bevy::animation::{AnimationTargetId, animated_field};
 use bevy::platform::collections::HashMap;
 use bevy::app::App;
 use bevy::prelude::*;
+
+/// Marker: VRMA clip needs baking.
+#[derive(Component)]
+pub(crate) struct NeedsBake;
 
 #[derive(Event)]
 pub(crate) struct RequestUpdateAnimationGraph {
@@ -31,7 +32,8 @@ impl Plugin for VrmaAnimationGraphPlugin {
     ) {
         app.add_observer(apply_animation_graph)
             .add_observer(apply_replace_humanoid_bone_animation_clips)
-            .add_observer(apply_regenerate_expression_clips);
+            .add_observer(apply_regenerate_expression_clips)
+            .add_systems(Update, apply_bake_clips);
     }
 }
 
@@ -192,6 +194,7 @@ fn apply_replace_humanoid_bone_animation_clips(
         &searcher,
         &bones,
     );
+    commands.entity(vrma_entity).insert(NeedsBake);
 }
 
 fn replace_bone_animation_clips(
@@ -237,40 +240,110 @@ fn replace_bone_animation_clips(
                 )])));
         }
         if let Some(curves) = animation_curves.remove(vrma_bone_target) {
-            let mut cs = Vec::new();
-            for c in curves.iter() {
-                cs.push(animation_curve(c.clone(), bone.as_str() == "hips"));
-            }
-            animation_curves.insert(*bone_target, cs);
+            animation_curves.insert(*bone_target, curves);
         }
     }
 }
 
-fn animation_curve(
-    original: VariableCurve,
-    hips: bool,
-) -> VariableCurve {
-    let EvaluatorId::ComponentField(target_component) = original.0.evaluator_id() else {
-        return original;
-    };
-
-    let translation_field = animated_field!(Transform::translation);
-    let EvaluatorId::ComponentField(translation_component) = translation_field.evaluator_id()
-    else {
-        return original;
-    };
+fn apply_bake_clips(world: &mut World) {
+    // Collect VRMA entities that need baking, including their AnimationNodeIndex
+    let mut to_bake: Vec<(Entity, Handle<AnimationClip>, AnimationNodeIndex)> = Vec::new();
+    {
+        let mut query = world.query_filtered::<(
+            Entity,
+            &VrmAnimationClipHandle,
+            &VrmAnimationNodeIndex,
+        ), With<NeedsBake>>();
+        for (entity, clip_handle, node_index) in query.iter(world) {
+            to_bake.push((entity, clip_handle.0.clone(), node_index.0));
+        }
+    }
+    if to_bake.is_empty() {
+        return;
+    }
 
     let rotation_field = animated_field!(Transform::rotation);
     let EvaluatorId::ComponentField(rotation_component) = rotation_field.evaluator_id() else {
-        return original;
+        return;
     };
+    let rotation_component = *rotation_component;
+    let translation_field = animated_field!(Transform::translation);
+    let EvaluatorId::ComponentField(translation_component) = translation_field.evaluator_id()
+    else {
+        return;
+    };
+    let translation_component = *translation_component;
 
-    if target_component == rotation_component {
-        VariableCurve(Box::new(BoneRotationAnimationCurve { base: original.0 }))
-    } else if hips && target_component == translation_component {
-        VariableCurve(Box::new(HipsTranslationAnimationCurve { base: original.0 }))
-    } else {
-        original
+    for (vrma_entity, clip_handle, node_index) in to_bake {
+        // Get the clip data first; only remove NeedsBake after successful fetch
+        let Some(clip) = world
+            .resource::<Assets<AnimationClip>>()
+            .get(clip_handle.id())
+            .cloned()
+        else {
+            continue;
+        };
+        world.entity_mut(vrma_entity).remove::<NeedsBake>();
+
+        let mut new_curves: HashMap<AnimationTargetId, Vec<VariableCurve>> = HashMap::new();
+
+        for (target_id, variable_curves) in clip.curves().iter() {
+            // Find the VRM bone entity that has this AnimationTargetId.
+            // Filter to entities with RetargetRotationTable to avoid matching VRMA bone entities.
+            let bone_entity = {
+                let mut q = world
+                    .query_filtered::<(Entity, &AnimationTargetId), With<RetargetRotationTable>>();
+                q.iter(world)
+                    .find(|(_, tid)| **tid == *target_id)
+                    .map(|(e, _)| e)
+            };
+
+            let mut baked_curves = Vec::new();
+            for vc in variable_curves.iter() {
+                let mut baked = false;
+
+                if let Some(bone) = bone_entity
+                    && let EvaluatorId::ComponentField(target) = vc.0.evaluator_id()
+                {
+                    if *target == rotation_component {
+                        // Use the specific VRMA's AnimationNodeIndex to get the correct transformation
+                        if let Some(table) = world.get::<RetargetRotationTable>(bone)
+                            && let Some(transformation) = table.0.get(&node_index).cloned()
+                            && let Some(baked_vc) =
+                                bake_rotation_curve(vc, &transformation, world)
+                        {
+                            baked_curves.push(baked_vc);
+                            baked = true;
+                        }
+                    } else if *target == translation_component
+                        && let Some(table) = world.get::<RetargetTranslationTable>(bone)
+                        && let Some(transformation) = table.0.get(&node_index).cloned()
+                        && let Some(baked_vc) =
+                            bake_translation_curve(vc, &transformation, world)
+                    {
+                        baked_curves.push(baked_vc);
+                        baked = true;
+                    }
+                }
+
+                if !baked {
+                    baked_curves.push(vc.clone());
+                }
+            }
+            new_curves.insert(*target_id, baked_curves);
+        }
+
+        // Replace the clip's curves with baked ones
+        let mut clip_assets = world.resource_mut::<Assets<AnimationClip>>();
+        if let Some(clip) = clip_assets.get_mut(clip_handle.id()) {
+            let curves = clip.curves_mut();
+            curves.clear();
+            for (target_id, variable_curves) in new_curves {
+                for vc in variable_curves {
+                    curves.entry(target_id).or_default().push(vc);
+                }
+            }
+        }
     }
 }
 

--- a/src/vrma/animation/bake.rs
+++ b/src/vrma/animation/bake.rs
@@ -1,0 +1,171 @@
+//! Clip baking via evaluator pipeline sampling.
+//!
+//! Samples existing [`VariableCurve`] values through the evaluator pipeline
+//! (`create_evaluator -> apply -> commit`), applies retarget transformations,
+//! and builds new standard [`AnimatableKeyframeCurve`] instances so that
+//! custom curve wrappers are no longer needed at runtime.
+
+use crate::vrma::animation::bone_rotation::Transformation as RotationTransformation;
+use crate::vrma::animation::bone_translation::Transformation as TranslationTransformation;
+use bevy::animation::{AnimationEntityMut, animated_field};
+use bevy::prelude::*;
+
+/// Samples per second when baking curves.
+const SAMPLE_RATE: f32 = 120.0;
+
+/// Bake a rotation [`VariableCurve`]: sample the original curve via the
+/// evaluator pipeline, apply the retarget transformation to each sample,
+/// and rebuild as a standard [`AnimatableKeyframeCurve<Quat>`].
+///
+/// Returns `None` if baking fails (e.g. domain is degenerate, curve has
+/// fewer than 2 resulting samples, or evaluator errors occur).
+pub(crate) fn bake_rotation_curve(
+    curve: &VariableCurve,
+    transformation: &RotationTransformation,
+    world: &mut World,
+) -> Option<VariableCurve> {
+    let domain = curve.0.domain();
+    let start = domain.start();
+    let end = domain.end();
+    let duration = end - start;
+    if duration <= 0.0 || !duration.is_finite() {
+        return None;
+    }
+
+    let sample_count = ((duration * SAMPLE_RATE).ceil() as usize).max(2);
+    let dt = duration / (sample_count - 1) as f32;
+
+    // Spawn a dummy entity with Transform for the evaluator to write into.
+    let dummy = world.spawn(Transform::default()).id();
+
+    let mut evaluator = curve.0.create_evaluator();
+    let graph_node = AnimationNodeIndex::new(0);
+
+    let mut keyframes: Vec<(f32, Quat)> = Vec::with_capacity(sample_count);
+
+    // Cache the query state outside the loop for efficiency.
+    let mut query = world.query::<AnimationEntityMut>();
+
+    for i in 0..sample_count {
+        let t = (start + dt * i as f32).min(end);
+
+        // Reset the dummy entity's rotation before sampling.
+        if let Some(mut tf) = world.get_mut::<Transform>(dummy) {
+            tf.rotation = Quat::IDENTITY;
+        }
+
+        // Step 1: apply() pushes the sampled value onto the evaluator stack.
+        if curve.0.apply(&mut *evaluator, t, 1.0, graph_node).is_err() {
+            world.despawn(dummy);
+            return None;
+        }
+
+        // Step 2: commit() pops from the stack and writes to the entity's Transform.
+        {
+            let Ok(entity_mut) = query.get_mut(world, dummy) else {
+                world.despawn(dummy);
+                return None;
+            };
+            if evaluator.commit(entity_mut).is_err() {
+                world.despawn(dummy);
+                return None;
+            }
+        }
+
+        // Step 3: Read the sampled rotation and apply the retarget transformation.
+        let sampled_rotation = world
+            .get::<Transform>(dummy)
+            .map(|tf| tf.rotation)
+            .unwrap_or(Quat::IDENTITY);
+
+        let retargeted = transformation.transform(sampled_rotation);
+        keyframes.push((t, retargeted));
+    }
+
+    world.despawn(dummy);
+
+    // Build a new standard AnimatableKeyframeCurve from the baked keyframes.
+    let baked_curve = AnimatableKeyframeCurve::new(keyframes).ok()?;
+    Some(VariableCurve::new(AnimatableCurve::new(
+        animated_field!(Transform::rotation),
+        baked_curve,
+    )))
+}
+
+/// Bake a translation [`VariableCurve`] for hips: sample the original curve
+/// via the evaluator pipeline, apply the retarget transformation to each
+/// sample, and rebuild as a standard [`AnimatableKeyframeCurve<Vec3>`].
+///
+/// Returns `None` if baking fails.
+pub(crate) fn bake_translation_curve(
+    curve: &VariableCurve,
+    transformation: &TranslationTransformation,
+    world: &mut World,
+) -> Option<VariableCurve> {
+    let domain = curve.0.domain();
+    let start = domain.start();
+    let end = domain.end();
+    let duration = end - start;
+    if duration <= 0.0 || !duration.is_finite() {
+        return None;
+    }
+
+    let sample_count = ((duration * SAMPLE_RATE).ceil() as usize).max(2);
+    let dt = duration / (sample_count - 1) as f32;
+
+    // Spawn a dummy entity with Transform for the evaluator to write into.
+    let dummy = world.spawn(Transform::default()).id();
+
+    let mut evaluator = curve.0.create_evaluator();
+    let graph_node = AnimationNodeIndex::new(0);
+
+    let mut keyframes: Vec<(f32, Vec3)> = Vec::with_capacity(sample_count);
+
+    // Cache the query state outside the loop for efficiency.
+    let mut query = world.query::<AnimationEntityMut>();
+
+    for i in 0..sample_count {
+        let t = (start + dt * i as f32).min(end);
+
+        // Reset the dummy entity's translation before sampling.
+        if let Some(mut tf) = world.get_mut::<Transform>(dummy) {
+            tf.translation = Vec3::ZERO;
+        }
+
+        // Step 1: apply() pushes the sampled value onto the evaluator stack.
+        if curve.0.apply(&mut *evaluator, t, 1.0, graph_node).is_err() {
+            world.despawn(dummy);
+            return None;
+        }
+
+        // Step 2: commit() pops from the stack and writes to the entity's Transform.
+        {
+            let Ok(entity_mut) = query.get_mut(world, dummy) else {
+                world.despawn(dummy);
+                return None;
+            };
+            if evaluator.commit(entity_mut).is_err() {
+                world.despawn(dummy);
+                return None;
+            }
+        }
+
+        // Step 3: Read the sampled translation and apply the retarget transformation.
+        let sampled_translation = world
+            .get::<Transform>(dummy)
+            .map(|tf| tf.translation)
+            .unwrap_or(Vec3::ZERO);
+
+        let retargeted = transformation.transform(sampled_translation);
+        keyframes.push((t, retargeted));
+    }
+
+    world.despawn(dummy);
+
+    // Build a new standard AnimatableKeyframeCurve from the baked keyframes.
+    let baked_curve = AnimatableKeyframeCurve::new(keyframes).ok()?;
+    Some(VariableCurve::new(AnimatableCurve::new(
+        animated_field!(Transform::translation),
+        baked_curve,
+    )))
+}

--- a/src/vrma/animation/bone_rotation.rs
+++ b/src/vrma/animation/bone_rotation.rs
@@ -61,4 +61,3 @@ impl Transformation {
         self.dist_rest * self.dist_rest_g.inverse() * normalized_local_rotation * self.dist_rest_g
     }
 }
-

--- a/src/vrma/animation/bone_rotation.rs
+++ b/src/vrma/animation/bone_rotation.rs
@@ -7,63 +7,43 @@ use bevy::platform::collections::HashMap;
 use bevy::prelude::*;
 use std::any::TypeId;
 use std::fmt::{Debug, Formatter};
-use std::sync::Mutex;
 
-pub(crate) fn register_rotate_transformation(
+/// Per-bone-entity component storing retarget rotation transformations keyed by AnimationNodeIndex.
+/// Automatically cleaned up via `despawn_recursive`.
+#[derive(Component, Default, Clone, Debug, Deref, DerefMut)]
+pub(crate) struct RetargetRotationTable(pub HashMap<AnimationNodeIndex, Transformation>);
+
+pub(crate) fn compute_rotation_transformations(
     vrma: Entity,
     node_index: AnimationNodeIndex,
     root_bone: Entity,
     registry: &HumanoidBoneRegistry,
     searcher: &ChildSearcher,
     bones: &Query<(&RestTransform, &RestGlobalTransform, &AnimationTargetId)>,
-) {
-    let transformations =
-        BoneRotateTransformations::new(vrma, node_index, root_bone, registry, searcher, bones);
-    BONE_ROTATION_TRANSFORMATIONS
-        .lock()
-        .expect("Failed to lock BONE_ROTATION_TRANSFORMATIONS")
-        .extend(transformations.0);
-}
-
-static BONE_ROTATION_TRANSFORMATIONS: Mutex<HashMap<(Entity, AnimationNodeIndex), Transformation>> =
-    Mutex::new(HashMap::new());
-
-#[derive(Clone, Debug, Deref, DerefMut)]
-struct BoneRotateTransformations(pub HashMap<(Entity, AnimationNodeIndex), Transformation>);
-
-impl BoneRotateTransformations {
-    pub fn new(
-        vrma: Entity,
-        node_index: AnimationNodeIndex,
-        root_bone: Entity,
-        registry: &HumanoidBoneRegistry,
-        searcher: &ChildSearcher,
-        bones: &Query<(&RestTransform, &RestGlobalTransform, &AnimationTargetId)>,
-    ) -> Self {
-        let mut transformations = HashMap::new();
-        for (bone, name) in registry.iter() {
-            let Some(vrma_bone_entity) = searcher.find_from_name(vrma, name) else {
-                continue;
-            };
-            let Some(rig_bone_entity) = searcher.find_by_bone_name(root_bone, bone) else {
-                continue;
-            };
-            let Some((rest, rest_g, _)) = bones.get(rig_bone_entity).ok() else {
-                continue;
-            };
-            let Some((vrma_rest, vrma_rest_g, _)) = bones.get(vrma_bone_entity).ok() else {
-                continue;
-            };
-            let transformation = Transformation {
-                src_rest: vrma_rest.0.rotation,
-                src_rest_g: vrma_rest_g.0.rotation(),
-                dist_rest: rest.0.rotation,
-                dist_rest_g: rest_g.0.rotation(),
-            };
-            transformations.insert((rig_bone_entity, node_index), transformation);
-        }
-        Self(transformations)
+) -> Vec<(Entity, AnimationNodeIndex, Transformation)> {
+    let mut result = Vec::new();
+    for (bone, name) in registry.iter() {
+        let Some(vrma_bone_entity) = searcher.find_from_name(vrma, name) else {
+            continue;
+        };
+        let Some(rig_bone_entity) = searcher.find_by_bone_name(root_bone, bone) else {
+            continue;
+        };
+        let Some((rest, rest_g, _)) = bones.get(rig_bone_entity).ok() else {
+            continue;
+        };
+        let Some((vrma_rest, vrma_rest_g, _)) = bones.get(vrma_bone_entity).ok() else {
+            continue;
+        };
+        let transformation = Transformation {
+            src_rest: vrma_rest.0.rotation,
+            src_rest_g: vrma_rest_g.0.rotation(),
+            dist_rest: rest.0.rotation,
+            dist_rest_g: rest_g.0.rotation(),
+        };
+        result.push((rig_bone_entity, node_index, transformation));
     }
+    result
 }
 
 #[derive(Debug, Copy, Clone, Reflect)]
@@ -118,8 +98,7 @@ impl AnimationCurve for BoneRotationAnimationCurve {
         Box::new(Evaluator {
             base: self.base.create_evaluator(),
             property: Box::new(animated_field!(Transform::rotation)),
-            nodes: Vec::default(),
-            transformations: HashMap::default(),
+            last_node: None,
         })
     }
 
@@ -134,33 +113,16 @@ impl AnimationCurve for BoneRotationAnimationCurve {
             let ty = TypeId::of::<Evaluator>();
             return Err(AnimationEvaluationError::InconsistentEvaluatorImplementation(ty));
         };
-        curve_evaluator.nodes.push(graph_node);
+        curve_evaluator.last_node = Some(graph_node);
         self.base
-            .apply(&mut *curve_evaluator.base, t, weight, graph_node)?;
-        //FIXME: Currently, blending multiple VRMAs with different initial poses results in incorrect interpolation.
-        // To fix this, we need to implement the following at this timing, but we cannot do it due to access scope issues.
-        // let curve_evaluator = curve_evaluator
-        //     .downcast_mut::<AnimatableCurveEvaluator<Quat>>()
-        //     .unwrap();
-        // let e = curve_evaluator
-        //     .evaluator
-        //     .stack
-        //     .pop()
-        //     .unwrap();
-        // curve_evaluator.evaluator.stack.push(BasicAnimationCurveEvaluatorStackElement{
-        //     value: self.transformations.0.get(graph_node).unwrap().transform(e.value),
-        //     weight,
-        //     graph_node,
-        // });
-        Ok(())
+            .apply(&mut *curve_evaluator.base, t, weight, graph_node)
     }
 }
 
 struct Evaluator {
     base: Box<dyn AnimationCurveEvaluator>,
     property: Box<dyn AnimatableProperty<Property = Quat>>,
-    nodes: Vec<AnimationNodeIndex>,
-    transformations: HashMap<(Entity, AnimationNodeIndex), Transformation>,
+    last_node: Option<AnimationNodeIndex>,
 }
 
 impl AnimationCurveEvaluator for Evaluator {
@@ -190,16 +152,17 @@ impl AnimationCurveEvaluator for Evaluator {
         &mut self,
         mut entity: AnimationEntityMut,
     ) -> std::result::Result<(), AnimationEvaluationError> {
-        let bone_entity = entity.id();
         self.base.commit(entity.reborrow())?;
-        let node_index = self.nodes.pop().unwrap();
-        let transformation = self
-            .transformations
-            .entry((bone_entity, node_index))
-            .or_insert_with(|| {
-                let t = BONE_ROTATION_TRANSFORMATIONS.lock().unwrap();
-                t.get(&(bone_entity, node_index)).cloned().unwrap()
-            });
+
+        let Some(node_index) = self.last_node.take() else {
+            return Ok(());
+        };
+        let Some(table) = entity.get::<RetargetRotationTable>() else {
+            return Ok(());
+        };
+        let Some(transformation) = table.0.get(&node_index).cloned() else {
+            return Ok(());
+        };
         let rotate = self.property.get_mut(&mut entity)?;
         *rotate = transformation.transform(*rotate);
         Ok(())

--- a/src/vrma/animation/bone_rotation.rs
+++ b/src/vrma/animation/bone_rotation.rs
@@ -1,14 +1,10 @@
 use crate::prelude::*;
 use crate::vrm::humanoid_bone::HumanoidBoneRegistry;
-use bevy::animation::{
-    AnimationEntityMut, AnimationEvaluationError, AnimationTargetId, animated_field,
-};
+use bevy::animation::AnimationTargetId;
 use bevy::platform::collections::HashMap;
 use bevy::prelude::*;
-use std::any::TypeId;
-use std::fmt::{Debug, Formatter};
 
-/// Per-bone-entity component storing retarget rotation transformations keyed by AnimationNodeIndex.
+/// Per-bone-entity component storing retarget rotation transformations keyed by `AnimationNodeIndex`.
 /// Automatically cleaned up via `despawn_recursive`.
 #[derive(Component, Default, Clone, Debug, Deref, DerefMut)]
 pub(crate) struct RetargetRotationTable(pub HashMap<AnimationNodeIndex, Transformation>);
@@ -66,105 +62,3 @@ impl Transformation {
     }
 }
 
-pub struct BoneRotationAnimationCurve {
-    pub base: Box<dyn AnimationCurve>,
-}
-
-impl Debug for BoneRotationAnimationCurve {
-    fn fmt(
-        &self,
-        f: &mut Formatter<'_>,
-    ) -> std::fmt::Result {
-        f.debug_struct("RetargetBoneAnimationCurve").finish()
-    }
-}
-
-impl AnimationCurve for BoneRotationAnimationCurve {
-    fn clone_value(&self) -> Box<dyn AnimationCurve> {
-        Box::new(Self {
-            base: self.base.clone_value(),
-        })
-    }
-
-    fn domain(&self) -> Interval {
-        self.base.domain()
-    }
-
-    fn evaluator_id(&self) -> EvaluatorId<'_> {
-        EvaluatorId::Type(TypeId::of::<Self>())
-    }
-
-    fn create_evaluator(&self) -> Box<dyn AnimationCurveEvaluator> {
-        Box::new(Evaluator {
-            base: self.base.create_evaluator(),
-            property: Box::new(animated_field!(Transform::rotation)),
-            last_node: None,
-        })
-    }
-
-    fn apply(
-        &self,
-        curve_evaluator: &mut dyn AnimationCurveEvaluator,
-        t: f32,
-        weight: f32,
-        graph_node: AnimationNodeIndex,
-    ) -> Result<(), AnimationEvaluationError> {
-        let Some(curve_evaluator) = curve_evaluator.downcast_mut::<Evaluator>() else {
-            let ty = TypeId::of::<Evaluator>();
-            return Err(AnimationEvaluationError::InconsistentEvaluatorImplementation(ty));
-        };
-        curve_evaluator.last_node = Some(graph_node);
-        self.base
-            .apply(&mut *curve_evaluator.base, t, weight, graph_node)
-    }
-}
-
-struct Evaluator {
-    base: Box<dyn AnimationCurveEvaluator>,
-    property: Box<dyn AnimatableProperty<Property = Quat>>,
-    last_node: Option<AnimationNodeIndex>,
-}
-
-impl AnimationCurveEvaluator for Evaluator {
-    fn blend(
-        &mut self,
-        graph_node: AnimationNodeIndex,
-    ) -> std::result::Result<(), AnimationEvaluationError> {
-        self.base.blend(graph_node)
-    }
-
-    fn add(
-        &mut self,
-        graph_node: AnimationNodeIndex,
-    ) -> std::result::Result<(), AnimationEvaluationError> {
-        self.base.add(graph_node)
-    }
-
-    fn push_blend_register(
-        &mut self,
-        weight: f32,
-        graph_node: AnimationNodeIndex,
-    ) -> std::result::Result<(), AnimationEvaluationError> {
-        self.base.push_blend_register(weight, graph_node)
-    }
-
-    fn commit(
-        &mut self,
-        mut entity: AnimationEntityMut,
-    ) -> std::result::Result<(), AnimationEvaluationError> {
-        self.base.commit(entity.reborrow())?;
-
-        let Some(node_index) = self.last_node.take() else {
-            return Ok(());
-        };
-        let Some(table) = entity.get::<RetargetRotationTable>() else {
-            return Ok(());
-        };
-        let Some(transformation) = table.0.get(&node_index).cloned() else {
-            return Ok(());
-        };
-        let rotate = self.property.get_mut(&mut entity)?;
-        *rotate = transformation.transform(*rotate);
-        Ok(())
-    }
-}

--- a/src/vrma/animation/bone_translation.rs
+++ b/src/vrma/animation/bone_translation.rs
@@ -4,30 +4,27 @@ use bevy::platform::collections::HashMap;
 use bevy::prelude::*;
 use std::any::TypeId;
 use std::fmt::{Debug, Formatter};
-use std::sync::Mutex;
 
-pub fn register_hips_translation_transformation(
+#[derive(Component, Default, Clone, Debug, Deref, DerefMut)]
+pub(crate) struct RetargetTranslationTable(pub HashMap<AnimationNodeIndex, Transformation>);
+
+pub(crate) fn compute_hips_transformation(
     node_index: AnimationNodeIndex,
-    hips: Entity,
     src_rest: &RestTransform,
     src_rest_g: &RestGlobalTransform,
     dist_rest: &RestTransform,
     dist_rest_g: &RestGlobalTransform,
-) {
-    let transformations = Transformation {
-        src_rest_local: src_rest.translation,
-        src_rest_g: src_rest_g.translation(),
-        dist_rest_local: dist_rest.translation,
-        dist_rest_g: dist_rest_g.translation(),
-    };
-    HIPS_TRANSFORMATIONS
-        .lock()
-        .expect("Failed to lock HIPS_TRANSFORMATIONS")
-        .insert((hips, node_index), transformations);
+) -> (AnimationNodeIndex, Transformation) {
+    (
+        node_index,
+        Transformation {
+            src_rest_local: src_rest.translation,
+            src_rest_g: src_rest_g.translation(),
+            dist_rest_local: dist_rest.translation,
+            dist_rest_g: dist_rest_g.translation(),
+        },
+    )
 }
-
-static HIPS_TRANSFORMATIONS: Mutex<HashMap<(Entity, AnimationNodeIndex), Transformation>> =
-    Mutex::new(HashMap::new());
 
 pub(crate) struct HipsTranslationAnimationCurve {
     pub base: Box<dyn AnimationCurve>,
@@ -64,8 +61,7 @@ impl AnimationCurve for HipsTranslationAnimationCurve {
         Box::new(RetargetEvaluator {
             base: self.base.create_evaluator(),
             property: Box::new(animated_field!(Transform::translation)),
-            nodes: Vec::new(),
-            transformations: HashMap::new(),
+            last_node: None,
         })
     }
 
@@ -80,19 +76,18 @@ impl AnimationCurve for HipsTranslationAnimationCurve {
             let ty = TypeId::of::<RetargetEvaluator>();
             return Err(AnimationEvaluationError::InconsistentEvaluatorImplementation(ty));
         };
-        curve_evaluator.nodes.push(graph_node);
+        curve_evaluator.last_node = Some(graph_node);
         self.base
-            .apply(&mut *curve_evaluator.base, t, weight, graph_node)?;
-        Ok(())
+            .apply(&mut *curve_evaluator.base, t, weight, graph_node)
     }
 }
 
 #[derive(Debug, Copy, Clone, Reflect)]
-struct Transformation {
-    src_rest_local: Vec3,
-    src_rest_g: Vec3,
-    dist_rest_local: Vec3,
-    dist_rest_g: Vec3,
+pub(crate) struct Transformation {
+    pub(crate) src_rest_local: Vec3,
+    pub(crate) src_rest_g: Vec3,
+    pub(crate) dist_rest_local: Vec3,
+    pub(crate) dist_rest_g: Vec3,
 }
 
 impl Transformation {
@@ -113,8 +108,7 @@ impl Transformation {
 struct RetargetEvaluator {
     base: Box<dyn AnimationCurveEvaluator>,
     property: Box<dyn AnimatableProperty<Property = Vec3>>,
-    nodes: Vec<AnimationNodeIndex>,
-    transformations: HashMap<(Entity, AnimationNodeIndex), Transformation>,
+    last_node: Option<AnimationNodeIndex>,
 }
 
 impl AnimationCurveEvaluator for RetargetEvaluator {
@@ -149,20 +143,18 @@ impl AnimationCurveEvaluator for RetargetEvaluator {
         mut entity: AnimationEntityMut,
     ) -> std::result::Result<(), AnimationEvaluationError> {
         let hips_bone = entity.id();
-        let node = self.nodes.pop().unwrap();
-        let transformation = self
-            .transformations
-            .entry((hips_bone, node))
-            .or_insert_with(|| {
-                let hips_transformations = HIPS_TRANSFORMATIONS
-                    .lock()
-                    .expect("Failed to lock HIPS_TRANSFORMATIONS");
-                hips_transformations
-                    .get(&(hips_bone, node))
-                    .cloned()
-                    .unwrap()
-            });
+        let node = self.last_node.take();
         self.base.commit(entity.reborrow())?;
+
+        let Some(node_index) = node else {
+            return Ok(());
+        };
+        let Some(table) = entity.get::<RetargetTranslationTable>() else {
+            return Ok(());
+        };
+        let Some(transformation) = table.0.get(&node_index).cloned() else {
+            return Ok(());
+        };
         let hips_pos = self.property.get_mut(&mut entity)?;
         *hips_pos = transformation.transform(*hips_pos);
         Ok(())
@@ -175,7 +167,7 @@ impl AnimationCurveEvaluator for RetargetEvaluator {
 /// (matching `Transform::translation` coordinate space), and **global** rest
 /// positions only for the Y-based height scaling ratio.
 #[inline]
-fn calc_hips_position(
+pub(crate) fn calc_hips_position(
     src_rest_local: Vec3,
     src_rest_global: Vec3,
     src_pose: Vec3,
@@ -192,6 +184,9 @@ fn calc_scaling(
     dist_rest_global_pos: Vec3,
     source_rest_global_pos: Vec3,
 ) -> f32 {
+    if source_rest_global_pos.y.abs() < f32::EPSILON {
+        return 1.0;
+    }
     dist_rest_global_pos.y / source_rest_global_pos.y
 }
 

--- a/src/vrma/animation/bone_translation.rs
+++ b/src/vrma/animation/bone_translation.rs
@@ -1,9 +1,6 @@
 use crate::prelude::{RestGlobalTransform, RestTransform};
-use bevy::animation::{AnimationEntityMut, AnimationEvaluationError, animated_field};
 use bevy::platform::collections::HashMap;
 use bevy::prelude::*;
-use std::any::TypeId;
-use std::fmt::{Debug, Formatter};
 
 #[derive(Component, Default, Clone, Debug, Deref, DerefMut)]
 pub(crate) struct RetargetTranslationTable(pub HashMap<AnimationNodeIndex, Transformation>);
@@ -26,62 +23,6 @@ pub(crate) fn compute_hips_transformation(
     )
 }
 
-pub(crate) struct HipsTranslationAnimationCurve {
-    pub base: Box<dyn AnimationCurve>,
-}
-
-impl Debug for HipsTranslationAnimationCurve {
-    fn fmt(
-        &self,
-        f: &mut Formatter<'_>,
-    ) -> std::fmt::Result {
-        f.debug_struct("RetargetBoneTranslationAnimationCurve")
-            .finish()
-    }
-}
-
-impl AnimationCurve for HipsTranslationAnimationCurve {
-    fn clone_value(&self) -> Box<dyn AnimationCurve> {
-        Box::new(Self {
-            base: self.base.clone_value(),
-        })
-    }
-
-    #[inline]
-    fn domain(&self) -> Interval {
-        self.base.domain()
-    }
-
-    #[inline]
-    fn evaluator_id(&self) -> EvaluatorId<'_> {
-        EvaluatorId::Type(TypeId::of::<RetargetEvaluator>())
-    }
-
-    fn create_evaluator(&self) -> Box<dyn AnimationCurveEvaluator> {
-        Box::new(RetargetEvaluator {
-            base: self.base.create_evaluator(),
-            property: Box::new(animated_field!(Transform::translation)),
-            last_node: None,
-        })
-    }
-
-    fn apply(
-        &self,
-        curve_evaluator: &mut dyn AnimationCurveEvaluator,
-        t: f32,
-        weight: f32,
-        graph_node: AnimationNodeIndex,
-    ) -> Result<(), AnimationEvaluationError> {
-        let Some(curve_evaluator) = curve_evaluator.downcast_mut::<RetargetEvaluator>() else {
-            let ty = TypeId::of::<RetargetEvaluator>();
-            return Err(AnimationEvaluationError::InconsistentEvaluatorImplementation(ty));
-        };
-        curve_evaluator.last_node = Some(graph_node);
-        self.base
-            .apply(&mut *curve_evaluator.base, t, weight, graph_node)
-    }
-}
-
 #[derive(Debug, Copy, Clone, Reflect)]
 pub(crate) struct Transformation {
     pub(crate) src_rest_local: Vec3,
@@ -102,62 +43,6 @@ impl Transformation {
             self.dist_rest_local,
             self.dist_rest_g,
         )
-    }
-}
-
-struct RetargetEvaluator {
-    base: Box<dyn AnimationCurveEvaluator>,
-    property: Box<dyn AnimatableProperty<Property = Vec3>>,
-    last_node: Option<AnimationNodeIndex>,
-}
-
-impl AnimationCurveEvaluator for RetargetEvaluator {
-    #[inline]
-    fn blend(
-        &mut self,
-        graph_node: AnimationNodeIndex,
-    ) -> std::result::Result<(), AnimationEvaluationError> {
-        self.base.blend(graph_node)
-    }
-
-    #[inline]
-    fn add(
-        &mut self,
-        graph_node: AnimationNodeIndex,
-    ) -> std::result::Result<(), AnimationEvaluationError> {
-        self.base.add(graph_node)
-    }
-
-    #[inline]
-    fn push_blend_register(
-        &mut self,
-        weight: f32,
-        graph_node: AnimationNodeIndex,
-    ) -> std::result::Result<(), AnimationEvaluationError> {
-        self.base.push_blend_register(weight, graph_node)
-    }
-
-    #[inline]
-    fn commit(
-        &mut self,
-        mut entity: AnimationEntityMut,
-    ) -> std::result::Result<(), AnimationEvaluationError> {
-        let hips_bone = entity.id();
-        let node = self.last_node.take();
-        self.base.commit(entity.reborrow())?;
-
-        let Some(node_index) = node else {
-            return Ok(());
-        };
-        let Some(table) = entity.get::<RetargetTranslationTable>() else {
-            return Ok(());
-        };
-        let Some(transformation) = table.0.get(&node_index).cloned() else {
-            return Ok(());
-        };
-        let hips_pos = self.property.get_mut(&mut entity)?;
-        *hips_pos = transformation.transform(*hips_pos);
-        Ok(())
     }
 }
 

--- a/src/vrma/initialize.rs
+++ b/src/vrma/initialize.rs
@@ -3,10 +3,10 @@
 use crate::error::vrm_error;
 use crate::vrm::Initialized;
 use crate::vrm::humanoid_bone::HumanoidBoneRegistry;
+use crate::vrma::animation::animation_graph::RequestUpdateAnimationGraph;
 use crate::vrma::animation::expressions::VrmaExpressionNames;
 use crate::vrma::gltf::extensions::VrmaExtensions;
 use crate::vrma::loader::VrmaAsset;
-use crate::vrma::animation::animation_graph::RequestUpdateAnimationGraph;
 use crate::vrma::{LoadedVrma, VrmAnimationClipHandle, Vrma, VrmaDuration, VrmaHandle, VrmaPath};
 use bevy::gltf::GltfNode;
 use bevy::prelude::*;

--- a/src/vrma/initialize.rs
+++ b/src/vrma/initialize.rs
@@ -6,6 +6,7 @@ use crate::vrm::humanoid_bone::HumanoidBoneRegistry;
 use crate::vrma::animation::expressions::VrmaExpressionNames;
 use crate::vrma::gltf::extensions::VrmaExtensions;
 use crate::vrma::loader::VrmaAsset;
+use crate::vrma::animation::animation_graph::RequestUpdateAnimationGraph;
 use crate::vrma::{LoadedVrma, VrmAnimationClipHandle, Vrma, VrmaDuration, VrmaHandle, VrmaPath};
 use bevy::gltf::GltfNode;
 use bevy::prelude::*;
@@ -28,6 +29,8 @@ fn spawn_vrma(
     vrma_assets: Res<Assets<VrmaAsset>>,
     node_assets: Res<Assets<GltfNode>>,
     mut clip_assets: ResMut<Assets<AnimationClip>>,
+    mut scene_assets: ResMut<Assets<Scene>>,
+    type_registry: Res<AppTypeRegistry>,
     vrma_handles: Query<(Entity, &VrmaHandle, &ChildOf)>,
     vrms: Query<Has<Initialized>>,
 ) {
@@ -49,10 +52,21 @@ fn spawn_vrma(
         };
         commands.entity(handle_entity).remove::<VrmaHandle>();
 
-        let Some(scene_root) = vrma.gltf.scenes.first().cloned() else {
+        let Some(scene_handle) = vrma.gltf.scenes.first() else {
             vrm_error!("[VRMA] Not found vrma scene in {name}");
             continue;
         };
+        // Clone the Scene asset per-VRMA instance to prevent SceneSpawner
+        // from grouping instances by shared AssetId and respawning them together.
+        let Some(source_scene) = scene_assets.get(scene_handle) else {
+            vrm_error!("[VRMA] Not found scene data for {name}");
+            continue;
+        };
+        let Ok(cloned_scene) = source_scene.clone_with(&type_registry) else {
+            vrm_error!("[VRMA] Failed to clone scene for {name}");
+            continue;
+        };
+        let scene_root = scene_assets.add(cloned_scene);
         let extensions = match VrmaExtensions::from_gltf(&vrma.gltf) {
             Ok(extensions) => extensions,
             Err(_e) => {
@@ -103,8 +117,15 @@ fn trigger_loaded(
     vrmas: Query<(Entity, &ChildOf), (Added<Initialized>, With<Vrma>)>,
 ) {
     for (vrma_entity, child_of) in vrmas.iter() {
+        let vrm_entity = child_of.parent();
+        // Trigger animation graph setup first (deferred from request_initialize
+        // to ensure VrmBone components are fully applied on the parent VRM's bones)
+        commands.trigger(RequestUpdateAnimationGraph {
+            vrma: vrma_entity,
+            vrm: vrm_entity,
+        });
         commands.trigger(LoadedVrma {
-            vrm: child_of.parent(),
+            vrm: vrm_entity,
             vrma: vrma_entity,
         });
     }


### PR DESCRIPTION
## Problem

Spawning 2+ VRMs from the same `.vrm` file and playing the same VRMA causes both animations to stop. Additionally, animation transitions between VRMAs with different initial poses produce incorrect interpolation (Issue #32).

**Root cause**: Bevy's `SceneSpawner` groups all scene instances sharing the same `Scene` `AssetId` and respawns them together on `AssetEvent::Modified`. When loading the same `.vrm` file for multiple VRM instances, the second VRM's glTF subasset loading triggers a scene-modified event, causing the first VRM's bone entities to be despawned and recreated — losing all custom components (`VrmBone`, `AnimationPlayer`, retarget state, etc.) that were inserted during initialization.

A secondary root cause is the retargeting architecture: custom `AnimationCurve` wrappers applied retarget transforms post-blend in `commit()`, which is mathematically incorrect when blending clips with different source rest poses.

## Solution

**Scene isolation**: Clone the `Scene` asset per-VRM/VRMA instance via `Scene::clone_with()`, giving each instance an independent `AssetId` and preventing cross-instance `SceneSpawner` respawn.

**Retarget redesign**: Replace the custom `BoneRotationAnimationCurve` / `HipsTranslationAnimationCurve` runtime wrappers with pre-baked clips. At initialization, each VRMA's animation curves are sampled through Bevy's evaluator pipeline (`create_evaluator → apply → commit`) at 120 Hz, retarget transformations are applied to the sampled values, and new standard `AnimatableKeyframeCurve` instances are built. This eliminates the need for custom curve wrappers and makes baked clips fully compatible with stock `AnimationTransitions`.

**Additional fixes**:
- Replaced process-global `static Mutex<HashMap>` retarget state with per-bone-entity `RetargetRotationTable` / `RetargetTranslationTable` components (auto-cleanup on despawn)
- Fixed `return` → `continue` in expression graph installation to prevent early loop abort
- Fixed `calc_scaling` division-by-zero edge case

## Test plan

- [x] `cargo test` — all 50 tests pass
- [x] `cargo clippy` — no warnings
- [x] `examples/deb.rs` — 2 VRMs from same file both animate independently
- [x] `examples/vrma_transition` — 4 VRMAs (including different initial pose) all retarget correctly
- [x] `examples/vrma` — single VRM + VRMA works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)