### PR TITLE
fix(mtoon): read EMISSIVE_TEXTURE bit from MToon uniform, not PbrInput.flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fixed MToon conversion skipping meshes whose glTF material name collided with another material: `VrmcMaterialRegistry` now resolves material handles by index instead of by name, so VRMs exported with duplicate material names (e.g. VRoid models with multiple `Body_mtoon` entries) no longer fall back to the default `StandardMaterial` for the collided meshes
 - Fixed MToon characters not being lit by directional lights that have `shadows_enabled: false`: the MToon shader was using `shadows_enabled` to gate the entire light contribution, which is inconsistent with Bevy PBR where `shadows_enabled` only controls shadow-map sampling. `apply_directional_lights` now accumulates every directional light's contribution, and `calc_mtoon_lighting_shading` defaults `shadow` to `1.0` when the light has no shadow map
+- Fixed full-viewport blackout on WebGPU when rendering MToon materials: `apply_emissive_light` was reading the `EMISSIVE_TEXTURE` bit from `PbrInput.flags` (the standard-material flags field, which `MToonMaterial` does not populate), causing an unbound-texture sample whose NaN/Inf output contaminated the HDR tonemap/bloom path. The shader now reads the bit from the MToon uniform `material.flags`, and `MtoonFlags::from(&MToonMaterial)` now actually sets the `EMISSIVE_TEXTURE` bit based on `emissive_texture.is_some()` so the branch works as intended
 
 ## v0.7.0
 

--- a/src/vrm/mtoon/material.rs
+++ b/src/vrm/mtoon/material.rs
@@ -259,6 +259,10 @@ impl From<&MToonMaterial> for MtoonFlags {
         );
         flags.set(MtoonFlags::MATCAP_TEXTURE, value.matcap_texture.is_some());
         flags.set(
+            MtoonFlags::EMISSIVE_TEXTURE,
+            value.emissive_texture.is_some(),
+        );
+        flags.set(
             MtoonFlags::ALPHA_MODE_MASK,
             matches!(value.alpha_mode, AlphaMode::Mask(_)),
         );

--- a/src/vrm/mtoon_fragment.wgsl
+++ b/src/vrm/mtoon_fragment.wgsl
@@ -238,7 +238,7 @@ fn calc_shade_color(in: MToonInput) -> vec3<f32>{
 
 fn apply_emissive_light(in: MToonInput) -> vec3<f32> {
     let emissive = in.pbr.material.emissive.rgb;
-    if ((in.pbr.flags & EMISSIVE_TEXTURE) != 0u) {
+    if ((material.flags & EMISSIVE_TEXTURE) != 0u) {
         return emissive * textureSampleBias(emissive_texture, emissive_sampler, in.uv, view.mip_bias).rgb;
     } else {
         return emissive;


### PR DESCRIPTION
## Summary

`apply_emissive_light` in `src/vrm/mtoon_fragment.wgsl` reads
`in.pbr.flags & EMISSIVE_TEXTURE`, but `PbrInput.flags` holds the
standard-material flags field. `MToonMaterial` is a custom material and
does not populate that field, so reads return undefined data.

MToon's `EMISSIVE_TEXTURE = 1u << 6u` also collides with
`bevy_pbr::pbr_types::STANDARD_MATERIAL_FLAGS_TWO_COMPONENT_NORMAL_MAP_BIT`
(also `1u << 6u`).

On WebGPU backends the garbage bit reads as set, the branch samples the
(unbound) `emissive_texture`, and the NaN/Inf output contaminates the
HDR tonemap/bloom path, causing a **full-viewport blackout** a frame or
two after the VRM becomes visible. On Metal-native macOS builds the
same uninitialized read happens to return zero, so the bug has been
invisible there.

All other MToon flag checks in this file already use `material.flags`
(the MToon uniform). This PR fixes the one outlier.

```diff
- if ((in.pbr.flags & EMISSIVE_TEXTURE) != 0u) {
+ if ((material.flags & EMISSIVE_TEXTURE) != 0u) {
```

## Reproduction

- Load any MToon-material VRM in a Bevy app running on WebGPU (e.g. a
  `wasm32-unknown-unknown` target in Chrome with WebGPU enabled).
- Spawn the character; the entire viewport (including non-character
  pixels) turns fully black within ~1s.
- No shader/runtime errors appear in the console. A latent
  `bevy_pbr::render::gpu_preprocess: The build mesh uniforms pipeline
  wasn't ready` warning shows up but is incidental.

## Evidence

All screenshots are captured from the same Chrome/WebGPU session on
macOS, right after clicking a "Spawn Debug Character" button that
inserts an MToon-material VRM.

**Before — `bevy_vrm1` 0.7.0 unmodified.** Viewport turns fully black
within ~1 s of the VRM becoming visible:

<img width="1024" height="768" alt="before: full-viewport blackout" src="https://github.com/user-attachments/assets/a31023b7-324a-4609-be37-93d5881336bf" />

**After — this one-line fix applied.** Character renders normally with
full MToon lighting (directional + GI + emissive + rim):

<img width="1024" height="768" alt="after: VRM renders normally" src="https://github.com/user-attachments/assets/b74d0050-477d-4745-9efc-d15bb38027f4" />

## Bisection

Isolating each call inside `apply_mtoon_lighting`, only
`apply_emissive_light` reproduced the blackout:

| Fragment returned | Blackout |
|---|---|
| `apply_directional_lights` only | no |
| `apply_global_illumination` only | no |
| `apply_emissive_light` only | **yes** |
| `apply_emissive_light` with the flag branch removed | no |
| `apply_mtoon_lighting` (full) + this fix | no |

## Risk

One-line shader change. No Rust-side code paths are modified.
Metal-native behavior is preserved: on that backend `in.pbr.flags`
happens to read as zero for MToon materials today, so the buggy branch
was never taken, and the new `material.flags` read is consistent with
every other flag check in this shader.

Happy to write a minimal WebGPU repro example or additional test if
that helps the review — just let me know what form you prefer.