### PR TITLE
fix: resolve VRMC material handles by index to avoid name-collision skip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Bug Fixes
+
+- Fixed MToon conversion skipping meshes whose glTF material name collided with another material: `VrmcMaterialRegistry` now resolves material handles by index instead of by name, so VRMs exported with duplicate material names (e.g. VRoid models with multiple `Body_mtoon` entries) no longer fall back to the default `StandardMaterial` for the collided meshes
+
 ## v0.7.0
 
 ### Breaking Changes

--- a/src/vrm/mtoon.rs
+++ b/src/vrm/mtoon.rs
@@ -77,12 +77,20 @@ impl VrmcMaterialRegistry {
         gltf: &Gltf,
         images: Vec<Handle<Image>>,
     ) -> Option<Self> {
+        // Match glTF materials to Bevy `StandardMaterial` handles by index,
+        // not by name. The glTF spec does not require material names to be
+        // unique, and some exporters (e.g. VRoid) produce multiple materials
+        // that share a name. `Gltf::named_materials` is a `HashMap` keyed by
+        // name, so duplicates collapse to a single entry and any meshes bound
+        // to the overwritten materials skip the MToon conversion entirely,
+        // rendering with the default `StandardMaterial` instead.
         let materials = gltf
             .source
             .as_ref()?
             .materials()
             .flat_map(|m| {
-                let asset_id = gltf.named_materials.get(m.name()?)?.id();
+                let index = m.index()?;
+                let asset_id = gltf.materials.get(index)?.id();
                 let extensions = m.extensions()?;
                 match serde_json::from_value(extensions.get("VRMC_materials_mtoon")?.clone()) {
                     Ok(properties) => Some((asset_id, properties)),


### PR DESCRIPTION
## Summary

`VrmcMaterialRegistry::try_new` resolves Bevy `StandardMaterial` handles
via `gltf.named_materials`, a `HashMap` keyed by material name. The glTF
spec does not require material names to be unique, and some exporters
(notably VRoid) emit VRMs with multiple materials that share a name. When
that happens, `HashMap::insert` silently overwrites the earlier entry, so
one of the duplicate-name materials never makes it into the registry.

Any mesh bound to the overwritten material then misses the MToon
conversion in `turn_to_mtoon_material` — the
`registry.materials.get(&handle.id())` lookup fails and the mesh keeps
its default `StandardMaterial`, rendering visibly darker than the
intended MToon output under scenes authored for toon shading.

Fix: resolve the handle by glTF material index instead of by name,
using `gltf.materials[idx]`. The index vector is populated one handle
per material regardless of name, so duplicates are preserved.

## Repro

- Any VRM with two or more materials sharing a name. We hit it on a VRoid
  export that contains two `Body_mtoon` materials (one for the main body
  mesh, one for an inner "Bassbody" skin layer). Meshes bound to the
  overwritten material were rendering unlit-PBR-dark while the rest of
  the model rendered correctly through MToon.

## Screenshot
<img width="1059" height="774" alt="Frame 45" src="https://github.com/user-attachments/assets/687d1b3f-d61b-4f63-9fc9-8a033cf56c02" />
Before / after on a VRoid VRM with duplicate `Body_mtoon` material
names. Before: Bassbody/arms skin layer renders as default
`StandardMaterial` (dark PBR). After: all skin meshes render via MToon.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib` (50 passed)
- [x] Visually verified on a VRoid VRM with duplicate material names in
      a downstream WebGPU consumer (see screenshot)

## Notes

- No behavior change for VRMs with unique material names (the old
  `named_materials` lookup returned the same handle that
  `gltf.materials[idx]` returns).
- Happy to add a regression test if you'd like — it would need a small
  glTF fixture with two same-named materials, since `Gltf::source`
  wraps the third-party `gltf::Gltf` type and is hard to build inline.
  Let me know the preferred form.