### PR TITLE
fix: surface MToon emissive texture by using material.flags and setting EMISSIVE_TEXTURE bit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Bug Fixes
+
+- Fixed MToon emissive texture never being sampled: `MtoonFlags::from` did not set the `EMISSIVE_TEXTURE` bit, and `apply_emissive_light` read `in.pbr.flags` (Bevy's standard `PbrInput.flags`, which is not populated for custom materials) instead of `material.flags`. Emissive maps now mask the emissive factor correctly instead of always applying a flat, unmasked color
+
 ## v0.7.0
 
 ### Breaking Changes

--- a/src/vrm/mtoon/material.rs
+++ b/src/vrm/mtoon/material.rs
@@ -259,6 +259,10 @@ impl From<&MToonMaterial> for MtoonFlags {
         );
         flags.set(MtoonFlags::MATCAP_TEXTURE, value.matcap_texture.is_some());
         flags.set(
+            MtoonFlags::EMISSIVE_TEXTURE,
+            value.emissive_texture.is_some(),
+        );
+        flags.set(
             MtoonFlags::ALPHA_MODE_MASK,
             matches!(value.alpha_mode, AlphaMode::Mask(_)),
         );

--- a/src/vrm/mtoon_fragment.wgsl
+++ b/src/vrm/mtoon_fragment.wgsl
@@ -229,7 +229,13 @@ fn calc_shade_color(in: MToonInput) -> vec3<f32>{
 
 fn apply_emissive_light(in: MToonInput) -> vec3<f32> {
     let emissive = in.pbr.material.emissive.rgb;
-    if ((in.pbr.flags & EMISSIVE_TEXTURE) != 0u) {
+    // Read MToon's own `material.flags`, not `in.pbr.flags`. Custom materials
+    // do not populate the standard `PbrInput.flags` field, so reading it
+    // yields undefined data and causes the emissive texture branch to fire
+    // or skip unpredictably. All other texture flag checks in this shader
+    // (BASE_COLOR_TEXTURE, SHADE_MULTIPLY_TEXTURE, etc.) already use
+    // `material.flags` — this brings emissive in line with them.
+    if ((material.flags & EMISSIVE_TEXTURE) != 0u) {
         return emissive * textureSampleBias(emissive_texture, emissive_sampler, in.uv, view.mip_bias).rgb;
     } else {
         return emissive;


### PR DESCRIPTION
## Summary

Two sides of the same bug prevented MToon emissive textures from ever being sampled.

### Side 1 — `MtoonFlags::EMISSIVE_TEXTURE` never set

`From<&MToonMaterial> for MtoonFlags` populates every other texture bit (`BASE_COLOR_TEXTURE`, `SHADING_SHIFT_TEXTURE`, `SHADE_MULTIPLY_TEXTURE`, `RIM_MAP_TEXTURE`, `UV_ANIMATION_MASK_TEXTURE`, `MATCAP_TEXTURE`, `OUTLINE_WIDTH_MULTIPLY_TEXTURE`) from the corresponding `Option<Handle<Image>>`, but it never sets `EMISSIVE_TEXTURE`. The bit stays zero even when a material carries an emissive texture.

### Side 2 — shader reads the wrong flags field

`apply_emissive_light` reads `in.pbr.flags & EMISSIVE_TEXTURE`, but `in.pbr.flags` is Bevy's standard `PbrInput.flags` field, which custom materials do not populate. Every other texture branch in this shader reads `material.flags` — emissive was the only outlier.

### Result

`emissive` was always returned as the flat `emissive_color` factor with no texture masking. Characters whose emissive maps were meant to isolate a small region (e.g. hair highlights) ended up with the factor flood-applied across the whole material.

## Fix

- Set `MtoonFlags::EMISSIVE_TEXTURE` from `value.emissive_texture.is_some()` alongside the other texture flags.
- Change `apply_emissive_light` to read `material.flags & EMISSIVE_TEXTURE`, matching the pattern used by every other texture branch in the file.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib` (50 passed)

## Notes

- No behavior change for materials without an emissive texture (the bit remains zero, the flat-factor branch still runs).
- Before this fix, `in.pbr.flags` happened to be whatever Bevy's PBR input initializer left it as — typically zero, which meant the texture branch never fired regardless of material configuration.