### PR TITLE
fix: include shadow-less directional lights in MToon direct lighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Bug Fixes
+
+- Fixed MToon characters not being lit by directional lights that have `shadows_enabled: false`: the MToon shader was using `shadows_enabled` to gate the entire light contribution, which is inconsistent with Bevy PBR where `shadows_enabled` only controls shadow-map sampling. `apply_directional_lights` now accumulates every directional light's contribution, and `calc_mtoon_lighting_shading` defaults `shadow` to `1.0` when the light has no shadow map
+
 ## v0.7.0
 
 ### Breaking Changes

--- a/src/vrm/mtoon_fragment.wgsl
+++ b/src/vrm/mtoon_fragment.wgsl
@@ -152,9 +152,12 @@ fn apply_directional_lights(in: MToonInput) -> vec3<f32>{
     var shade_color: vec3<f32> = calc_shade_color(in);
     var shading: f32 = 0.0;
     for (var i: u32 = 0u; i < lights.n_directional_lights; i = i + 1u) {
-        if (lights.directional_lights[i].flags & DIRECTIONAL_LIGHT_FLAGS_SHADOWS_ENABLED_BIT) == 0u {
-            continue;
-        }
+        // Keep the light's direct contribution regardless of whether shadow
+        // maps are enabled for it. `shadows_enabled` gates shadow-map
+        // sampling only; Bevy PBR treats it the same way. Previously this
+        // loop skipped the entire light when shadows were disabled, which
+        // made shadow-less directional lights fail to illuminate MToon
+        // characters at all.
         shading += calc_mtoon_lighting_shading(in, i);
     }
     return mix(shade_color, in.lit_color.rgb, shading);
@@ -174,12 +177,18 @@ fn calc_mtoon_lighting_shading(
         view.view_from_world[2].z,
         view.view_from_world[3].z
     ), input.world_position);
-    var shadow = fetch_directional_shadow(
-        light_id,
-        input.world_position,
-        input.world_normal,
-        view_z,
-    );
+    // Only sample the shadow map when this light actually casts shadows;
+    // default to full illumination otherwise so the light still contributes
+    // to MToon shading.
+    var shadow = 1.0;
+    if ((*light).flags & DIRECTIONAL_LIGHT_FLAGS_SHADOWS_ENABLED_BIT) != 0u {
+        shadow = fetch_directional_shadow(
+            light_id,
+            input.world_position,
+            input.world_normal,
+            view_z,
+        );
+    }
     let shading =  mtoon_linearstep(-1.0 + material.shading_toony_factor, 1.0 - material.shading_toony_factor, shade_input + shade_shift) * shadow;
    return shading;
 }


### PR DESCRIPTION
## Summary

`apply_directional_lights` in the MToon fragment shader skips any directional light whose `DIRECTIONAL_LIGHT_FLAGS_SHADOWS_ENABLED_BIT` flag is zero:

```wgsl
for (var i: u32 = 0u; i < lights.n_directional_lights; i = i + 1u) {
    if (lights.directional_lights[i].flags & DIRECTIONAL_LIGHT_FLAGS_SHADOWS_ENABLED_BIT) == 0u {
        continue;
    }
    shading += calc_mtoon_lighting_shading(in, i);
}
```

This treats `shadows_enabled` as if it gated the light's diffuse contribution, but in Bevy PBR `shadows_enabled` only controls whether a shadow map is bound and sampled — the light still contributes to direct lighting regardless. Bevy's own PBR shader accumulates every directional light unconditionally.

The observed behavior: MToon characters went completely unlit under scenes that used shadow-less directional lights (e.g. fill lights added to soften toon shading without casting shadows).

## Fix

- Remove the `continue` in `apply_directional_lights` so every directional light's shading term is summed.
- Move the `DIRECTIONAL_LIGHT_FLAGS_SHADOWS_ENABLED_BIT` check into `calc_mtoon_lighting_shading`, where it now only guards the `fetch_directional_shadow` call. When no shadow map is bound, `shadow` defaults to `1.0` and the light still lights the surface.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib` (50 passed)

## Notes

- No behavior change for shadow-casting directional lights (same branch path, same shadow sampling).
- Matches Bevy PBR's handling of `shadows_enabled` so MToon and PBR characters respond identically to light configuration in the same scene.