### PR TITLE
Migration to bevy 0.19.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,6 +190,7 @@ When modifying update order or system timing, always reference:
 
 | bevy_vrm1 | bevy |
 |-----------|------|
+| 0.8.0 ~   | 0.19 |
 | 0.5.0 ~   | 0.18 |
 | 0.4.0 ~   | 0.17 |
 | 0.1.0 ~   | 0.16 |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_vrm1"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2024"
 authors = ["notelm <elmprograminfo@gmail.com>"]
 description = "Allows you to use VRM and VRMA in Bevy"
@@ -12,7 +12,7 @@ readme = "README.md"
 exclude = ["assets/"]
 
 [dependencies]
-bevy = { version = "0.18", default-features = false, features = [
+bevy = { version = "0.19", default-features = false, features = [
     "bevy_render",
     "bevy_window",
     "bevy_asset",
@@ -21,12 +21,14 @@ bevy = { version = "0.18", default-features = false, features = [
     "gltf_animation",
     "bevy_mesh",
     "bevy_shader",
+    "bevy_pbr",
 ] }
 serde = "1"
 serde_json = "1"
 anyhow = "1"
 bitflags = { version = "2.9" }
 paste = "1"
+indexmap = "2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.59", features = [
@@ -35,9 +37,9 @@ windows = { version = "0.59", features = [
 ] }
 
 [dev-dependencies]
-bevy = { version = "0.18" }
+bevy = { version = "0.19" }
 bevy_test_helper = { git = "https://github.com/not-elm/bevy_test_helper", branch = "v0.18" }
-bevy_panorbit_camera = "0.34.0"
+bevy_panorbit_camera = "0.35.0"
 
 [lints.clippy]
 type_complexity = "allow"

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ All constraint types use spherical linear interpolation (slerp) based on the wei
 
 | bevy_vrm1 | bevy |
 |-----------|------|
+| 0.8.0 ~   | 0.19 |
 | 0.5.0 ~   | 0.18 |
 | 0.4.0 ~   | 0.17 |
 | 0.1.0 ~   | 0.16 |

--- a/examples/expressions.rs
+++ b/examples/expressions.rs
@@ -25,7 +25,7 @@ fn main() {
 fn spawn_light(mut commands: Commands) {
     commands.spawn((
         DirectionalLight {
-            shadows_enabled: true,
+            shadow_maps_enabled: true,
             ..default()
         },
         Transform::from_xyz(3.0, 3.0, 0.3).looking_at(Vec3::ZERO, Vec3::Y),

--- a/examples/look_at_cursor.rs
+++ b/examples/look_at_cursor.rs
@@ -18,7 +18,7 @@ fn main() {
 fn spawn_directional_light(mut commands: Commands) {
     commands.spawn((
         DirectionalLight {
-            shadows_enabled: true,
+            shadow_maps_enabled: true,
             ..default()
         },
         Transform::from_xyz(3.0, 3.0, 0.3).looking_at(Vec3::ZERO, Vec3::Y),

--- a/examples/look_at_target.rs
+++ b/examples/look_at_target.rs
@@ -15,7 +15,7 @@ fn main() {
 fn spawn_directional_light(mut commands: Commands) {
     commands.spawn((
         DirectionalLight {
-            shadows_enabled: true,
+            shadow_maps_enabled: true,
             ..default()
         },
         Transform::from_xyz(3.0, 3.0, 0.3).looking_at(Vec3::ZERO, Vec3::Y),

--- a/examples/multiple_lights.rs
+++ b/examples/multiple_lights.rs
@@ -21,7 +21,7 @@ fn spawn_directional_light(mut commands: Commands) {
     commands.spawn((
         RotateCircle,
         DirectionalLight {
-            shadows_enabled: true,
+            shadow_maps_enabled: true,
             ..default()
         },
         Transform::from_xyz(3.0, 3.0, 0.3).looking_at(Vec3::ZERO, Vec3::Y),
@@ -30,7 +30,7 @@ fn spawn_directional_light(mut commands: Commands) {
     commands.spawn((
         RotateArc,
         DirectionalLight {
-            shadows_enabled: true,
+            shadow_maps_enabled: true,
             ..default()
         },
         Transform::from_xyz(1.0, 1., 2.).looking_at(Vec3::ZERO, Vec3::Y),

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -12,7 +12,7 @@ fn main() {
 fn spawn_directional_light(mut commands: Commands) {
     commands.spawn((
         DirectionalLight {
-            shadows_enabled: true,
+            shadow_maps_enabled: true,
             ..default()
         },
         Transform::from_xyz(3.0, 3.0, 0.3).looking_at(Vec3::ZERO, Vec3::Y),

--- a/examples/spring_bone.rs
+++ b/examples/spring_bone.rs
@@ -16,7 +16,7 @@ fn main() {
 fn spawn_directional_light(mut commands: Commands) {
     commands.spawn((
         DirectionalLight {
-            shadows_enabled: true,
+            shadow_maps_enabled: true,
             ..default()
         },
         Transform::from_xyz(3.0, 3.0, 0.3).looking_at(Vec3::ZERO, Vec3::Y),

--- a/examples/vrma.rs
+++ b/examples/vrma.rs
@@ -15,7 +15,7 @@ fn main() {
 fn spawn_directional_light(mut commands: Commands) {
     commands.spawn((
         DirectionalLight {
-            shadows_enabled: true,
+            shadow_maps_enabled: true,
             ..default()
         },
         Transform::from_xyz(3.0, 3.0, 0.3).looking_at(Vec3::ZERO, Vec3::Y),

--- a/examples/vrma_transition.rs
+++ b/examples/vrma_transition.rs
@@ -37,7 +37,7 @@ fn main() {
 fn spawn_directional_light(mut commands: Commands) {
     commands.spawn((
         DirectionalLight {
-            shadows_enabled: true,
+            shadow_maps_enabled: true,
             ..default()
         },
         Transform::from_xyz(3.0, 3.0, 0.3).looking_at(Vec3::ZERO, Vec3::Y),

--- a/src/system_param/child_searcher.rs
+++ b/src/system_param/child_searcher.rs
@@ -87,6 +87,7 @@ fn find_entity(
 mod tests {
     use crate::prelude::*;
     use crate::tests::test_app;
+    use bevy::ecs::system::RunSystemOnce;
     use bevy::prelude::*;
     use bevy_test_helper::system::SystemExt;
 
@@ -101,7 +102,9 @@ mod tests {
             .with_child(Name::new(Vrm::ROOT_BONE));
         app.update();
 
-        app.run_system_once(move |s: ChildSearcher| s.find_root_bone(vrm))
+        app.world_mut()
+            .run_system_once(move |s: ChildSearcher| s.find_root_bone(vrm))
+            .unwrap()
             .expect("Failed to find root bone");
     }
 }

--- a/src/system_param/parent_searcher.rs
+++ b/src/system_param/parent_searcher.rs
@@ -42,6 +42,7 @@ mod tests {
     use crate::prelude::*;
     use crate::system_param::parent_searcher::ParentSearcher;
     use crate::tests::test_app;
+    use bevy::ecs::system::RunSystemOnce;
     use bevy_test_helper::system::SystemExt;
 
     #[test]
@@ -53,7 +54,10 @@ mod tests {
         app.world_mut().commands().entity(vrm).add_child(child);
         app.update();
 
-        let actual = app.run_system_once(move |s: ParentSearcher| s.find_vrm(child));
+        let actual = app
+            .world_mut()
+            .run_system_once(move |s: ParentSearcher| s.find_vrm(child))
+            .unwrap();
         assert_eq!(actual, Some(vrm));
     }
 
@@ -68,7 +72,10 @@ mod tests {
         app.world_mut().commands().entity(vrm).add_child(child);
         app.update();
 
-        let actual = app.run_system_once(move |s: ParentSearcher| s.find_vrm(child));
+        let actual = app
+            .world_mut()
+            .run_system_once(move |s: ParentSearcher| s.find_vrm(child))
+            .unwrap();
         assert_eq!(actual, Some(vrm));
     }
 }

--- a/src/vrm/detach.rs
+++ b/src/vrm/detach.rs
@@ -11,7 +11,7 @@ use crate::vrm::spring_bone::registry::{
 };
 use crate::vrm::{Initialized, RestGlobalTransform, RestTransform, Vrm, VrmPath};
 use bevy::prelude::*;
-use bevy::scene::SceneRoot;
+use bevy::world_serialization::{WorldAsset, WorldAssetRoot};
 
 /// Triggers VRM detachment on the target entity.
 ///
@@ -70,7 +70,7 @@ fn remove_vrm_components(
         .try_remove::<Initialized>()
         .try_remove::<VrmHandle>()
         .try_remove::<Name>()
-        .try_remove::<SceneRoot>()
+        .try_remove::<WorldAssetRoot>()
         // Rest transforms
         .try_remove::<RestTransform>()
         .try_remove::<RestGlobalTransform>()

--- a/src/vrm/initialize.rs
+++ b/src/vrm/initialize.rs
@@ -16,7 +16,7 @@ use bevy::app::{App, Update};
 use bevy::asset::Assets;
 use bevy::gltf::GltfNode;
 use bevy::prelude::*;
-use bevy::scene::SceneRoot;
+use bevy::world_serialization::{WorldAsset, WorldAssetRoot};
 
 pub(crate) struct VrmInitializePlugin;
 
@@ -31,9 +31,10 @@ impl Plugin for VrmInitializePlugin {
 
 fn spawn_vrm(
     mut commands: Commands,
+    asset_server: Res<AssetServer>,
     node_assets: Res<Assets<GltfNode>>,
     vrm_assets: Res<Assets<VrmAsset>>,
-    mut scene_assets: ResMut<Assets<Scene>>,
+    mut scene_assets: ResMut<Assets<WorldAsset>>,
     type_registry: Res<AppTypeRegistry>,
     handles: Query<(Entity, &VrmHandle)>,
 ) {
@@ -69,8 +70,8 @@ fn spawn_vrm(
         cmd.insert((
             Vrm,
             Name::new(extensions.name().unwrap_or_else(|| "VRM".to_string())),
-            SceneRoot(scene),
-            VrmcMaterialRegistry::new(&vrm.gltf, vrm.images.clone()),
+            WorldAssetRoot(scene),
+            VrmcMaterialRegistry::new(&vrm.gltf, vrm.images.clone(), &asset_server),
             VrmExpressionRegistry::new(&extensions, &node_assets, &vrm.gltf.nodes),
             HumanoidBoneRegistry::new(
                 &extensions.vrmc_vrm.humanoid.human_bones,

--- a/src/vrm/loader.rs
+++ b/src/vrm/loader.rs
@@ -55,6 +55,7 @@ impl Plugin for VrmLoaderPlugin {
             default_sampler,
             default_convert_coordinates: Default::default(),
             extensions,
+            default_skinned_mesh_bounds_policy: Default::default(),
         }));
     }
 }
@@ -68,7 +69,7 @@ impl Plugin for VrmLoaderPlugin {
 /// - [`VrmPath`](crate::prelude::VrmPath)
 /// - [`BoneRestTransform`](crate::prelude::RestTransform)
 /// - [`BoneRestGlobalTransform`](crate::prelude::RestGlobalTransform)
-/// - [`SceneRoot`](bevy::scene::SceneRoot)
+/// - [`WorldAssetRoot`](bevy::world_serialization::WorldAssetRoot)
 /// - Components hold the entity of each bone, refer to [here](crate::vrm::humanoid_bone) for more details.
 ///
 /// ```no_run

--- a/src/vrm/mtoon.rs
+++ b/src/vrm/mtoon.rs
@@ -69,13 +69,15 @@ impl VrmcMaterialRegistry {
     pub fn new(
         gltf: &Gltf,
         images: Vec<Handle<Image>>,
+        asset_server: &AssetServer,
     ) -> Self {
-        Self::try_new(gltf, images).unwrap_or_default()
+        Self::try_new(gltf, images, asset_server).unwrap_or_default()
     }
 
     fn try_new(
         gltf: &Gltf,
         images: Vec<Handle<Image>>,
+        asset_server: &AssetServer,
     ) -> Option<Self> {
         // Match glTF materials to Bevy `StandardMaterial` handles by index,
         // not by name. The glTF spec does not require material names to be
@@ -90,7 +92,10 @@ impl VrmcMaterialRegistry {
             .materials()
             .flat_map(|m| {
                 let index = m.index()?;
-                let asset_id = gltf.materials.get(index)?.id();
+                let gltf_material_path = gltf.materials.get(index)?.path()?;
+                let std_label = format!("{}/std", gltf_material_path.label()?);
+                let std_path = gltf_material_path.clone().with_label(std_label);
+                let asset_id = asset_server.load::<StandardMaterial>(std_path).id();
                 let extensions = m.extensions()?;
                 match serde_json::from_value(extensions.get("VRMC_materials_mtoon")?.clone()) {
                     Ok(properties) => Some((asset_id, properties)),

--- a/src/vrm/mtoon/material.rs
+++ b/src/vrm/mtoon/material.rs
@@ -5,9 +5,10 @@ mod uv_animation;
 
 use crate::vrm::mtoon::material::outline::{MToonOutline, OutlineWidthMode};
 use crate::vrm::mtoon::{MTOON_FRAGMENT_SHADER_HANDLE, MTOON_VERTEX_SHADER_HANDLE};
+use bevy::material::OpaqueRendererMethod;
 use bevy::math::Affine2;
 use bevy::mesh::MeshVertexBufferLayoutRef;
-use bevy::pbr::{MaterialPipeline, MaterialPipelineKey, OpaqueRendererMethod};
+use bevy::pbr::{MaterialPipeline, MaterialPipelineKey};
 use bevy::prelude::*;
 use bevy::render::render_asset::RenderAssets;
 use bevy::render::render_resource::{
@@ -160,7 +161,7 @@ impl Material for MToonMaterial {
                 .bind_group_data
                 .intersects(MToonMaterialKey::TRANSPARENT_WITH_Z_WRITE)
         {
-            stencil.depth_write_enabled = true;
+            stencil.depth_write_enabled = Some(true);
         }
         Ok(())
     }

--- a/src/vrm/mtoon/outline_pass.rs
+++ b/src/vrm/mtoon/outline_pass.rs
@@ -7,18 +7,18 @@ use crate::error::vrm_error;
 use crate::vrm::mtoon::outline_pass::phase_item::OutlinePhaseItem;
 use crate::vrm::mtoon::outline_pass::pipeline::{MToonOutlinePipeline, OutlinePipelineKey};
 use crate::vrm::mtoon::outline_pass::render_command::DrawOutline;
-use crate::vrm::mtoon::outline_pass::view_node::{OutlineDrawNode, OutlineDrawPassLabel};
 use crate::vrm::mtoon::{MToonMaterial, MToonMaterialKey};
+use bevy::core_pipeline::core_3d::main_transparent_pass_3d;
+use bevy::core_pipeline::{Core3d, Core3dSystems};
 use bevy::pbr::{
     MaterialBindGroupAllocators, MaterialPipeline, MaterialPipelineKey, PreparedMaterial,
     RenderMeshInstanceFlags, ViewKeyCache, alpha_mode_pipeline_key, init_material_pipeline,
     queue_material_meshes,
 };
-use bevy::render::RenderStartup;
 use bevy::render::sync_world::MainEntityHashMap;
 use bevy::render::view::RenderVisibilityRanges;
+use bevy::render::{GpuResourceAppExt, RenderStartup};
 use bevy::{
-    core_pipeline::core_3d::graph::{Core3d, Node3d},
     math::FloatOrd,
     pbr::{MeshPipeline, MeshPipelineKey, RenderMeshInstances},
     platform::collections::HashSet,
@@ -28,7 +28,6 @@ use bevy::{
         erased_render_asset::ErasedRenderAssets,
         mesh::RenderMesh,
         render_asset::RenderAssets,
-        render_graph::{RenderGraphExt, ViewNodeRunner},
         render_phase::{
             AddRenderCommand, DrawFunctions, PhaseItemExtraIndex, SortedRenderPhasePlugin,
             ViewSortedRenderPhases, sort_phase_system,
@@ -55,7 +54,7 @@ impl Plugin for MToonOutlinePlugin {
             return;
         };
         render_app
-            .init_resource::<SpecializedMeshPipelines<MToonOutlinePipeline>>()
+            .init_gpu_resource::<SpecializedMeshPipelines<MToonOutlinePipeline>>()
             .init_resource::<DrawFunctions<OutlinePhaseItem>>()
             .add_render_command::<OutlinePhaseItem, DrawOutline>()
             .init_resource::<ViewSortedRenderPhases<OutlinePhaseItem>>()
@@ -77,16 +76,12 @@ impl Plugin for MToonOutlinePlugin {
             )
             .add_systems(Render, queue_outlines.after(queue_material_meshes));
 
-        render_app
-            .add_render_graph_node::<ViewNodeRunner<OutlineDrawNode>>(Core3d, OutlineDrawPassLabel)
-            .add_render_graph_edges(
-                Core3d,
-                (
-                    Node3d::MainTransparentPass,
-                    OutlineDrawPassLabel,
-                    Node3d::EndMainPass,
-                ),
-            );
+        render_app.add_systems(
+            Core3d,
+            view_node::outline_draw_pass
+                .in_set(Core3dSystems::MainPass)
+                .after(main_transparent_pass_3d),
+        );
     }
 }
 
@@ -105,7 +100,7 @@ fn extract_camera_phases(
         }
 
         let retained_view_entity = RetainedViewEntity::new(main_entity.into(), None, 0);
-        outline_phases.insert_or_clear(retained_view_entity);
+        outline_phases.prepare_for_new_frame(retained_view_entity);
         live_entities.insert(retained_view_entity);
     }
 
@@ -144,12 +139,15 @@ fn queue_outlines(
             continue;
         };
         let draw_function_id = draw_functions.read().id::<DrawOutline>();
-        for (render_entity, visible_entity) in visible_entities.iter::<Mesh3d>() {
+        let Some(visible_mesh_entities) = visible_entities.get::<Mesh3d>() else {
+            continue;
+        };
+        for (render_entity, visible_entity) in &visible_mesh_entities.entities_cpu_culling {
             let Some(mesh_instance) = render_mesh_instances.render_mesh_queue_data(*visible_entity)
             else {
                 continue;
             };
-            let Some(mesh) = render_meshes.get(mesh_instance.mesh_asset_id) else {
+            let Some(mesh) = render_meshes.get(mesh_instance.mesh_asset_id()) else {
                 continue;
             };
             let Some(asset_id) = instances.get(visible_entity) else {
@@ -159,7 +157,8 @@ fn queue_outlines(
                 continue;
             };
 
-            let mut mesh_pipeline_key_bits = material.properties.mesh_pipeline_key_bits;
+            let mut mesh_pipeline_key_bits: MeshPipelineKey =
+                material.properties.mesh_pipeline_key_bits.downcast();
             mesh_pipeline_key_bits.insert(alpha_mode_pipeline_key(
                 material.properties.alpha_mode,
                 &Msaa::from_samples(view_key.msaa_samples()),
@@ -174,13 +173,13 @@ fn queue_outlines(
 
             if view_key.contains(MeshPipelineKey::MOTION_VECTOR_PREPASS) {
                 if mesh_instance
-                    .flags
+                    .flags()
                     .contains(RenderMeshInstanceFlags::HAS_PREVIOUS_SKIN)
                 {
                     mesh_key |= MeshPipelineKey::HAS_PREVIOUS_SKIN;
                 }
                 if mesh_instance
-                    .flags
+                    .flags()
                     .contains(RenderMeshInstanceFlags::HAS_PREVIOUS_MORPH)
                 {
                     mesh_key |= MeshPipelineKey::HAS_PREVIOUS_MORPH;
@@ -220,7 +219,7 @@ fn queue_outlines(
             };
             let distance = material.properties.depth_bias;
             {
-                outline_phase.add(OutlinePhaseItem {
+                outline_phase.add_transient(OutlinePhaseItem {
                     sort_key: FloatOrd(distance),
                     entity: (*render_entity, *visible_entity),
                     pipeline: pipeline_id,

--- a/src/vrm/mtoon/outline_pass/phase_item.rs
+++ b/src/vrm/mtoon/outline_pass/phase_item.rs
@@ -1,3 +1,4 @@
+use bevy::ecs::entity::EntityHash;
 use bevy::math::FloatOrd;
 use bevy::prelude::Entity;
 use bevy::render::render_phase::{
@@ -5,6 +6,8 @@ use bevy::render::render_phase::{
 };
 use bevy::render::render_resource::CachedRenderPipelineId;
 use bevy::render::sync_world::MainEntity;
+use bevy::render::view::ExtractedView;
+use indexmap::IndexMap;
 use std::ops::Range;
 
 pub(super) struct OutlinePhaseItem {
@@ -63,8 +66,14 @@ impl SortedPhaseItem for OutlinePhaseItem {
     }
 
     #[inline]
-    fn sort(items: &mut [Self]) {
-        items.sort_by_key(SortedPhaseItem::sort_key);
+    fn sort(items: &mut IndexMap<(Entity, MainEntity), Self, EntityHash>) {
+        items.sort_by_key(|_, item| item.sort_key());
+    }
+
+    fn recalculate_sort_keys(
+        _items: &mut IndexMap<(Entity, MainEntity), Self, EntityHash>,
+        _view: &ExtractedView,
+    ) {
     }
 
     #[inline]

--- a/src/vrm/mtoon/outline_pass/pipeline.rs
+++ b/src/vrm/mtoon/outline_pass/pipeline.rs
@@ -71,7 +71,7 @@ impl SpecializedMeshPipeline for MToonOutlinePipeline {
             .push(material_bind_group_def.clone());
         descriptor.vertex.shader_defs.push(PASS_NAME.into());
         if let Some(depth_stencil) = descriptor.depth_stencil.as_mut() {
-            depth_stencil.depth_compare = CompareFunction::GreaterEqual;
+            depth_stencil.depth_compare = Some(CompareFunction::GreaterEqual);
         }
         descriptor.primitive.cull_mode.replace(Face::Front);
         if let Some(fragment) = descriptor.fragment.as_mut() {

--- a/src/vrm/mtoon/outline_pass/view_node.rs
+++ b/src/vrm/mtoon/outline_pass/view_node.rs
@@ -1,59 +1,48 @@
 use crate::error::vrm_error;
 use crate::vrm::mtoon::outline_pass::phase_item::OutlinePhaseItem;
-use bevy::ecs::query::QueryItem;
-use bevy::prelude::World;
+use bevy::prelude::*;
 use bevy::render::camera::ExtractedCamera;
-use bevy::render::render_graph::{NodeRunError, RenderGraphContext, RenderLabel, ViewNode};
 use bevy::render::render_phase::ViewSortedRenderPhases;
 use bevy::render::render_resource::{RenderPassDescriptor, StoreOp};
-use bevy::render::renderer::RenderContext;
+use bevy::render::renderer::{RenderContext, ViewQuery};
 use bevy::render::view::{ExtractedView, ViewDepthTexture, ViewTarget};
 
-#[derive(RenderLabel, Debug, Clone, Hash, PartialEq, Eq)]
-pub(super) struct OutlineDrawPassLabel;
+pub(super) fn outline_draw_pass(
+    world: &World,
+    view: ViewQuery<(
+        &ExtractedCamera,
+        &ExtractedView,
+        &ViewTarget,
+        &ViewDepthTexture,
+    )>,
+    outline_phases: Res<ViewSortedRenderPhases<OutlinePhaseItem>>,
+    mut render_context: RenderContext,
+) {
+    let view_entity = view.entity();
+    let (camera, extracted_view, target, depth_texture) = view.into_inner();
 
-#[derive(Default)]
-pub(super) struct OutlineDrawNode;
+    let Some(outline_pass) = outline_phases.get(&extracted_view.retained_view_entity) else {
+        return;
+    };
+    if outline_pass.items.is_empty() {
+        return;
+    }
 
-impl ViewNode for OutlineDrawNode {
-    type ViewQuery = (
-        &'static ExtractedCamera,
-        &'static ExtractedView,
-        &'static ViewTarget,
-        &'static ViewDepthTexture,
-    );
-
-    fn run<'w>(
-        &self,
-        graph: &mut RenderGraphContext,
-        render_context: &mut RenderContext<'w>,
-        (camera, view, target, depth_texture): QueryItem<'w, '_, Self::ViewQuery>,
-        world: &'w World,
-    ) -> bevy::prelude::Result<(), NodeRunError> {
-        let Some(outline_phases) = world.get_resource::<ViewSortedRenderPhases<OutlinePhaseItem>>()
-        else {
-            return Ok(());
-        };
-
-        if let Some(outline_pass) = outline_phases.get(&view.retained_view_entity) {
-            let view_entity = graph.view_entity();
-            let mut render_pass = render_context.begin_tracked_render_pass(RenderPassDescriptor {
-                label: Some("outline pass"),
-                color_attachments: &[Some(target.get_color_attachment())],
-                depth_stencil_attachment: Some(depth_texture.get_attachment(StoreOp::Store)),
-                timestamp_writes: None,
-                occlusion_query_set: None,
-            });
-            if let Some(viewport) = camera.viewport.as_ref() {
-                render_pass.set_camera_viewport(viewport);
-            }
-            if let Err(err) = outline_pass.render(&mut render_pass, world, view_entity) {
-                vrm_error!(
-                    "Error encountered while rendering the mtoon outline phase",
-                    err
-                );
-            }
-        };
-        Ok(())
+    let mut render_pass = render_context.begin_tracked_render_pass(RenderPassDescriptor {
+        label: Some("outline pass"),
+        color_attachments: &[Some(target.get_color_attachment())],
+        depth_stencil_attachment: Some(depth_texture.get_attachment(StoreOp::Store)),
+        timestamp_writes: None,
+        occlusion_query_set: None,
+        multiview_mask: None,
+    });
+    if let Some(viewport) = camera.viewport.as_ref() {
+        render_pass.set_camera_viewport(viewport);
+    }
+    if let Err(err) = outline_pass.render(&mut render_pass, world, view_entity) {
+        vrm_error!(
+            "Error encountered while rendering the mtoon outline phase",
+            err
+        );
     }
 }

--- a/src/vrm/mtoon_fragment.wgsl
+++ b/src/vrm/mtoon_fragment.wgsl
@@ -187,6 +187,7 @@ fn calc_mtoon_lighting_shading(
             input.world_position,
             input.world_normal,
             view_z,
+            input.pbr.frag_coord.xy,
         );
     }
     let shading =  mtoon_linearstep(-1.0 + material.shading_toony_factor, 1.0 - material.shading_toony_factor, shade_input + shade_shift) * shadow;

--- a/src/vrm/mtoon_vertex.wgsl
+++ b/src/vrm/mtoon_vertex.wgsl
@@ -5,7 +5,7 @@
         mesh_normal_local_to_world,
     },
     skinning,
-    morph::morph,
+    morph::{morph_position, morph_normal, morph_tangent},
     forward_io::{Vertex, VertexOutput},
     view_transformations::position_world_to_clip,
     mesh_view_bindings::globals,
@@ -26,7 +26,7 @@ fn vertex(vertex_no_morph: Vertex) -> VertexOutput {
     var out: VertexOutput;
 
 #ifdef MORPH_TARGETS
-    var vertex = morph_vertex(vertex_no_morph);
+    var vertex = morph_vertex(vertex_no_morph, vertex_no_morph.instance_index);
 #else
     var vertex = vertex_no_morph;
 #endif
@@ -126,23 +126,23 @@ fn calc_uv_time(uv: vec2<f32>) -> f32{
 }
 
 #ifdef MORPH_TARGETS
-fn morph_vertex(vertex_in: Vertex) -> Vertex {
+fn morph_vertex(vertex_in: Vertex, instance_index: u32) -> Vertex {
     var vertex = vertex_in;
-    let first_vertex = mesh[vertex.instance_index].first_vertex_index;
+    let first_vertex = mesh[instance_index].first_vertex_index;
     let vertex_index = vertex.index - first_vertex;
 
-    let weight_count = bevy_pbr::morph::layer_count();
+    let weight_count = bevy_pbr::morph::layer_count(instance_index);
     for (var i: u32 = 0u; i < weight_count; i ++) {
-        let weight = bevy_pbr::morph::weight_at(i);
+        let weight = bevy_pbr::morph::weight_at(i, instance_index);
         if weight == 0.0 {
             continue;
         }
-        vertex.position += weight * morph(vertex_index, bevy_pbr::morph::position_offset, i);
+        vertex.position += weight * morph_position(vertex_index, i, instance_index);
 #ifdef VERTEX_NORMALS
-        vertex.normal += weight * morph(vertex_index, bevy_pbr::morph::normal_offset, i);
+        vertex.normal += weight * morph_normal(vertex_index, i, instance_index);
 #endif
 #ifdef VERTEX_TANGENTS
-        vertex.tangent += vec4(weight * morph(vertex_index, bevy_pbr::morph::tangent_offset, i), 0.0);
+        vertex.tangent += vec4(weight * morph_tangent(vertex_index, i, instance_index), 0.0);
 #endif
     }
     return vertex;

--- a/src/vrma.rs
+++ b/src/vrma.rs
@@ -55,7 +55,7 @@ impl Plugin for VrmaPlugin {
 /// - [`VrmaDuration`]
 /// - [`BoneRestTransform`](crate::prelude::RestTransform)
 /// - [`BoneRestGlobalTransform`](crate::prelude::RestGlobalTransform)
-/// - [`SceneRoot`](bevy::scene::SceneRoot)
+/// - [`WorldAssetRoot`](bevy::world_serialization::WorldAssetRoot)
 /// - [`VrmaAnimationPlayers`](crate::prelude::VrmaAnimationPlayers)
 /// - Components hold the entity of each bone, refer to [here](crate::vrm::humanoid_bone) for more details.
 #[derive(Debug, Component, Reflect)]

--- a/src/vrma/animation.rs
+++ b/src/vrma/animation.rs
@@ -38,7 +38,7 @@ impl Plugin for VrmaAnimationPlayersPlugin {
                 PostUpdate,
                 request_redraw
                     .in_set(VrmSystemSets::DetermineRedraw)
-                    .run_if(any_playing_animations.or(any_update_spring_joints)),
+                    .run_if(any_playing_animations.or_else(any_update_spring_joints)),
             );
     }
 }

--- a/src/vrma/animation/animation_graph.rs
+++ b/src/vrma/animation/animation_graph.rs
@@ -165,7 +165,7 @@ fn apply_replace_humanoid_bone_animation_clips(
         return;
     };
     // Note: AnimationClip is already cloned per-VRMA in initialize.rs:67-71
-    let Some(clip) = clips.get_mut(vrm_animation_clip_handle.0.id()) else {
+    let Some(mut clip) = clips.get_mut(vrm_animation_clip_handle.0.id()) else {
         return;
     };
     let transformations = compute_rotation_transformations(
@@ -190,7 +190,7 @@ fn apply_replace_humanoid_bone_animation_clips(
     }
     replace_bone_animation_clips(
         &mut commands,
-        clip,
+        &mut clip,
         vrma_node_index.0,
         vrma_entity,
         root_bone,
@@ -337,7 +337,7 @@ fn apply_bake_clips(world: &mut World) {
 
         // Replace the clip's curves with baked ones
         let mut clip_assets = world.resource_mut::<Assets<AnimationClip>>();
-        if let Some(clip) = clip_assets.get_mut(clip_handle.id()) {
+        if let Some(mut clip) = clip_assets.get_mut(clip_handle.id()) {
             let curves = clip.curves_mut();
             curves.clear();
             for (target_id, variable_curves) in new_curves {
@@ -368,7 +368,7 @@ fn apply_regenerate_expression_clips(
     let Ok(vrm_animation_clip_handle) = clip_handles.get(vrma_entity) else {
         return;
     };
-    let Some(clip) = clips.get_mut(vrm_animation_clip_handle.0.id()) else {
+    let Some(mut clip) = clips.get_mut(vrm_animation_clip_handle.0.id()) else {
         return;
     };
     let Ok(registry) = expressions.get(vrm_entity) else {

--- a/src/vrma/animation/play.rs
+++ b/src/vrma/animation/play.rs
@@ -212,6 +212,7 @@ mod tests {
     use crate::tests::test_app;
     use crate::vrma::VrmAnimationNodeIndex;
     use crate::vrma::animation::play::VrmaAnimationPlayPlugin;
+    use bevy::ecs::system::RunSystemOnce;
     use bevy::prelude::*;
     use bevy_test_helper::system::SystemExt;
 
@@ -237,10 +238,12 @@ mod tests {
             .trigger(PlayVrma::new);
         app.update();
 
-        app.run_system_once(|player: Query<&AnimationPlayer>| {
-            let player = player.single().expect("Failed to find AnimationPlayer");
-            assert!(!player.all_finished());
-        });
+        app.world_mut()
+            .run_system_once(|player: Query<&AnimationPlayer>| {
+                let player = player.single().expect("Failed to find AnimationPlayer");
+                assert!(!player.all_finished());
+            })
+            .unwrap();
     }
 
     #[test]
@@ -270,9 +273,11 @@ mod tests {
             .trigger(|entity| StopVrma { entity });
         app.update();
 
-        app.run_system_once(|player: Query<&AnimationPlayer>| {
-            let player = player.single().expect("Failed to find AnimationPlayer");
-            assert!(player.all_finished());
-        });
+        app.world_mut()
+            .run_system_once(|player: Query<&AnimationPlayer>| {
+                let player = player.single().expect("Failed to find AnimationPlayer");
+                assert!(player.all_finished());
+            })
+            .unwrap();
     }
 }

--- a/src/vrma/initialize.rs
+++ b/src/vrma/initialize.rs
@@ -10,7 +10,7 @@ use crate::vrma::loader::VrmaAsset;
 use crate::vrma::{LoadedVrma, VrmAnimationClipHandle, Vrma, VrmaDuration, VrmaHandle, VrmaPath};
 use bevy::gltf::GltfNode;
 use bevy::prelude::*;
-use bevy::scene::SceneRoot;
+use bevy::world_serialization::{WorldAsset, WorldAssetRoot};
 use std::time::Duration;
 
 pub(super) struct VrmaInitializePlugin;
@@ -29,7 +29,7 @@ fn spawn_vrma(
     vrma_assets: Res<Assets<VrmaAsset>>,
     node_assets: Res<Assets<GltfNode>>,
     mut clip_assets: ResMut<Assets<AnimationClip>>,
-    mut scene_assets: ResMut<Assets<Scene>>,
+    mut scene_assets: ResMut<Assets<WorldAsset>>,
     type_registry: Res<AppTypeRegistry>,
     vrma_handles: Query<(Entity, &VrmaHandle, &ChildOf)>,
     vrms: Query<Has<Initialized>>,
@@ -87,7 +87,7 @@ fn spawn_vrma(
             Vrma,
             Name::new(name),
             VrmAnimationClipHandle(animation_clip_handle.clone()),
-            SceneRoot(scene_root),
+            WorldAssetRoot(scene_root),
             VrmaDuration(obtain_vrma_duration(&clip_assets, &vrma.gltf.animations)),
             VrmaPath(vrma_path),
             VrmaExpressionNames::new(&extensions),

--- a/src/vrma/loader.rs
+++ b/src/vrma/loader.rs
@@ -54,8 +54,9 @@ impl Plugin for VrmaLoaderPlugin {
             supported_compressed_formats,
             custom_vertex_attributes: Default::default(),
             default_sampler,
-            default_convert_coordinates: default(),
+            default_convert_coordinates: Default::default(),
             extensions,
+            default_skinned_mesh_bounds_policy: Default::default(),
         }));
     }
 }


### PR DESCRIPTION
## Summary
Migrates bevy_vrm1 from Bevy 0.18 to Bevy 0.19.

## Breaking changes
- SceneRoot/Assets<Scene> -> WorldAssetRoot/Assets<WorldAsset> (bevy_world_serialization)
- OpaqueRendererMethod moved to bevy::material
- DirectionalLight/PointLight/SpotLight: shadows_enabled -> shadow_maps_enabled
- MToon WGSL shaders updated for the new fetch_directional_shadow signature (contact shadows) and the storage-buffer morph target API

## Testing
- cargo check, cargo test, cargo test --features log
- cargo run --example simple/vrma/multiple_lights/spring_bone (visual check: MToon shading, outlines, morphs, spring bones, animations)

## Spec impact
No changes to VRM/VRMA spec behavior - pure Bevy API compatibility update.