### PR TITLE
feat: support VRMC_vrm.firstPerson mesh annotations

### DIFF
--- a/examples/first_person.rs
+++ b/examples/first_person.rs
@@ -1,0 +1,176 @@
+//! Demonstrates `VRMC_vrm.firstPerson` support.
+//!
+//! The main window shows the avatar in third person. Press `F` to switch the
+//! main camera between third-person and first-person render layers: in
+//! first-person mode the avatar's head (the part split off by `auto`)
+//! disappears from the main window.
+//!
+//! The small dark viewport in the top-left corner is a camera attached to the
+//! head bone, tilted down: it sees the floor, the cubes and the body, but
+//! never the head.
+
+use bevy::camera::visibility::RenderLayers;
+use bevy::camera::{ClearColorConfig, Viewport};
+use bevy::prelude::*;
+use bevy_vrm1::prelude::*;
+
+#[derive(Component)]
+struct MainCamera;
+
+#[derive(Resource, Default)]
+struct FirstPersonMode {
+    enabled: bool,
+    saved_camera: Option<Transform>,
+}
+
+fn main() {
+    App::new()
+        .add_plugins((DefaultPlugins, VrmPlugin))
+        .init_resource::<FirstPersonMode>()
+        .add_systems(Startup, (spawn_main_camera, spawn_scene, spawn_vrm))
+        .add_systems(
+            Update,
+            (
+                attach_head_camera,
+                (toggle_main_camera, sync_first_person_camera).chain(),
+            ),
+        )
+        .run();
+}
+
+fn spawn_scene(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    commands.spawn((
+        DirectionalLight {
+            shadow_maps_enabled: true,
+            ..default()
+        },
+        Transform::from_xyz(3.0, 3.0, 0.3).looking_at(Vec3::ZERO, Vec3::Y),
+    ));
+    // Ground.
+    commands.spawn((
+        Mesh3d(meshes.add(Plane3d::new(Vec3::Y, Vec2::new(30.0, 30.0)))),
+        MeshMaterial3d(materials.add(StandardMaterial::from(Color::WHITE))),
+    ));
+    // Reference cubes in front of the avatar (VRM 1.0 avatars face +Z),
+    // so the first-person camera has something to look at.
+    for (x, z, color) in [
+        (-1.0, 4.5, Color::srgb(0.9, 0.3, 0.3)),
+        (0.0, 5.0, Color::srgb(0.3, 0.9, 0.3)),
+        (1.0, 4.5, Color::srgb(0.3, 0.3, 0.9)),
+    ] {
+        commands.spawn((
+            Mesh3d(meshes.add(Cuboid::new(0.4, 0.4, 0.4))),
+            MeshMaterial3d(materials.add(StandardMaterial::from(color))),
+            Transform::from_xyz(x, 0.2, z),
+        ));
+    }
+}
+
+/// The main camera starts in third-person mode
+/// (the `ThirdPersonCamera` observer assigns its render layers).
+fn spawn_main_camera(mut commands: Commands) {
+    commands.spawn((
+        Camera3d::default(),
+        MainCamera,
+        ThirdPersonCamera,
+        Transform::from_xyz(0.0, 1.2, 2.5).looking_at(Vec3::new(0.0, 1.0, 0.0), Vec3::Y),
+    ));
+}
+
+fn spawn_vrm(
+    mut commands: Commands,
+    asset_server: Res<AssetServer>,
+) {
+    commands.spawn(VrmHandle(asset_server.load("vrm/AliciaSolid.vrm")));
+}
+
+/// Once the avatar has finished loading, attaches a picture-in-picture camera
+/// to the head bone and enables first-person mode (this performs the `auto` head split).
+fn attach_head_camera(
+    mut commands: Commands,
+    vrms: Query<(Entity, &HeadBoneEntity), Added<HeadBoneEntity>>,
+) {
+    for (vrm, head) in vrms.iter() {
+        commands.entity(head.0).with_children(|spawner| {
+            spawner.spawn((
+                Camera3d::default(),
+                Camera {
+                    // Render on top of the main camera.
+                    order: 1,
+                    viewport: Some(Viewport {
+                        physical_position: UVec2::new(10, 10),
+                        physical_size: UVec2::new(400, 300),
+                        ..default()
+                    }),
+                    // A distinct background makes the viewport clearly visible.
+                    clear_color: ClearColorConfig::Custom(Color::srgb(0.05, 0.05, 0.15)),
+                    ..default()
+                },
+                FirstPersonCamera,
+                // At eye level, tilted down so the body is in view.
+                Transform::from_xyz(0.0, 0.06, 0.0)
+                    .looking_to(Dir3::new(Vec3::new(0.0, -0.4, 1.0)).unwrap(), Vec3::Y),
+            ));
+        });
+        commands.entity(vrm).trigger(RequestEnableFirstPerson);
+    }
+}
+
+/// Press `F` to toggle the main camera between the external third-person view
+/// and a true first-person view from the avatar's eyes: both the render
+/// layers and the camera transform are switched.
+fn toggle_main_camera(
+    keys: Res<ButtonInput<KeyCode>>,
+    layers: Res<FirstPersonLayers>,
+    mut mode: ResMut<FirstPersonMode>,
+    mut cameras: Query<(&mut Transform, &mut RenderLayers), With<MainCamera>>,
+) {
+    if !keys.just_pressed(KeyCode::KeyF) {
+        return;
+    }
+    mode.enabled = !mode.enabled;
+    for (mut transform, mut render_layers) in cameras.iter_mut() {
+        if mode.enabled {
+            // Remember the external view to restore it later.
+            mode.saved_camera = Some(*transform);
+            *render_layers = RenderLayers::default().with(layers.first_person_only);
+        } else {
+            if let Some(saved) = mode.saved_camera.take() {
+                *transform = saved;
+            }
+            *render_layers = RenderLayers::default().with(layers.third_person_only);
+        }
+    }
+}
+
+/// While first-person mode is enabled, the main camera follows the head bone
+/// every frame (so it also tracks animations).
+fn sync_first_person_camera(
+    mode: Res<FirstPersonMode>,
+    vrms: Query<&HeadBoneEntity>,
+    globals: Query<&GlobalTransform>,
+    mut cameras: Query<&mut Transform, With<MainCamera>>,
+) {
+    if !mode.enabled {
+        return;
+    }
+    let Some(head) = vrms.iter().next() else {
+        return;
+    };
+    let Ok(head_global) = globals.get(head.0) else {
+        return;
+    };
+    // Eye position slightly above the head joint; VRM 1.0 avatars face +Z.
+    // GlobalTransform is one frame behind, which is fine for a demo.
+    let eye = head_global.transform_point(Vec3::new(0.0, 0.06, 0.0));
+    let Ok(forward) = Dir3::new(head_global.rotation() * Vec3::Z) else {
+        return;
+    };
+    for mut transform in cameras.iter_mut() {
+        *transform = Transform::from_translation(eye).looking_to(forward, Vec3::Y);
+    }
+}

--- a/src/vrm.rs
+++ b/src/vrm.rs
@@ -1,6 +1,7 @@
 pub mod body_tracking;
 pub mod detach;
 pub(crate) mod expressions;
+pub(crate) mod first_person;
 pub(crate) mod gltf;
 pub(crate) mod humanoid_bone;
 mod initialize;
@@ -26,6 +27,7 @@ use bevy::asset::AssetApp;
 use bevy::prelude::*;
 use bevy::transform::systems::{propagate_parent_transforms, sync_simple_transforms};
 use expressions::VrmExpressionPlugin;
+use first_person::VrmFirstPersonPlugin;
 use mtoon::MtoonMaterialPlugin;
 use std::path::PathBuf;
 
@@ -38,6 +40,10 @@ pub mod prelude {
         expressions::{
             BinaryExpression, ClearExpressions, ExpressionEntityMap, ExpressionOverride,
             ExpressionOverrideSettings, ExpressionOverrideType, ModifyExpressions, SetExpressions,
+        },
+        first_person::{
+            FirstPersonCamera, FirstPersonLayers, FirstPersonRegistry, RequestDisableFirstPerson,
+            RequestEnableFirstPerson, ThirdPersonCamera,
         },
         gltf::prelude::*,
         humanoid_bone::prelude::*,
@@ -128,6 +134,7 @@ impl Plugin for VrmPlugin {
             MtoonMaterialPlugin,
             LookAtPlugin,
             BodyTrackingPlugin,
+            VrmFirstPersonPlugin,
         ));
 
         // Add manual transform propagation systems to follow VRM spec update order

--- a/src/vrm/detach.rs
+++ b/src/vrm/detach.rs
@@ -1,5 +1,6 @@
 use crate::vrm::body_tracking::{BodyTracking, SmoothedGaze};
 use crate::vrm::expressions::{ExpressionEntityMap, VrmExpressionRegistry};
+use crate::vrm::first_person::FirstPersonRegistry;
 use crate::vrm::gltf::extensions::vrmc_vrm::LookAtProperties;
 use crate::vrm::humanoid_bone::HumanoidBoneRegistry;
 use crate::vrm::loader::VrmHandle;
@@ -84,6 +85,7 @@ fn remove_vrm_components(
         .try_remove::<SpringJointPropsRegistry>()
         .try_remove::<SpringColliderRegistry>()
         .try_remove::<SpringNodeRegistry>()
+        .try_remove::<FirstPersonRegistry>()
         // Gaze/Body
         .try_remove::<LookAtProperties>()
         .try_remove::<LookAt>()

--- a/src/vrm/first_person.rs
+++ b/src/vrm/first_person.rs
@@ -1,0 +1,465 @@
+//! Provides support for `VRMC_vrm.firstPerson`.
+//!
+//! | firstPersonFlag | RenderLayers |
+//! |---|---|
+//! | `both` | 0 (default) |
+//! | `thirdPersonOnly` | `FirstPersonLayers::third_person_only` |
+//! | `firstPersonOnly` | `FirstPersonLayers::first_person_only` |
+//! | `auto` | mesh is split: head part -> thirdPersonOnly, the rest -> both |
+
+use crate::prelude::ChildSearcher;
+use crate::prelude::MToonMaterial;
+use crate::vrm::Vrm;
+use crate::vrm::gltf::extensions::vrmc_vrm::{FirstPerson, FirstPersonFlag};
+use crate::vrm::prelude::HeadBoneEntity;
+use bevy::app::{App, Plugin, Update};
+use bevy::asset::{Assets, Handle};
+use bevy::camera::visibility::{Layer, RenderLayers};
+use bevy::ecs::lifecycle::Add;
+use bevy::ecs::reflect::ReflectComponent;
+use bevy::ecs::{
+    component::Component,
+    entity::Entity,
+    event::EntityEvent,
+    hierarchy::{ChildOf, Children},
+    name::Name,
+    observer::On,
+    query::{With, Without},
+    resource::Resource,
+    system::{Commands, Query, Res, ResMut},
+};
+use bevy::gltf::GltfNode;
+use bevy::mesh::morph::MeshMorphWeights;
+use bevy::mesh::{Indices, Mesh, Mesh3d, skinning::SkinnedMesh};
+use bevy::pbr::MeshMaterial3d;
+use bevy::platform::collections::HashSet;
+use bevy::prelude::Deref;
+use bevy::reflect::Reflect;
+
+pub(crate) struct VrmFirstPersonPlugin;
+
+impl Plugin for VrmFirstPersonPlugin {
+    fn build(
+        &self,
+        app: &mut App,
+    ) {
+        app.init_resource::<FirstPersonLayers>()
+            .register_type::<FirstPersonRegistry>()
+            .register_type::<FirstPersonCamera>()
+            .register_type::<ThirdPersonCamera>()
+            .add_observer(setup_first_person_camera)
+            .add_observer(setup_third_person_camera)
+            .add_observer(apply_enable_first_person)
+            .add_observer(apply_disable_first_person)
+            .add_systems(Update, split_auto_meshes);
+    }
+}
+
+/// Holds `(node name, firstPersonFlag)` pairs from `VRMC_vrm.firstPerson.meshAnnotations`.
+#[derive(Component, Deref, Reflect, Default)]
+pub struct FirstPersonRegistry(Vec<(Name, FirstPersonFlag)>);
+
+impl FirstPersonRegistry {
+    pub fn new(
+        first_person: Option<&FirstPerson>,
+        node_assets: &Assets<GltfNode>,
+        nodes: &[Handle<GltfNode>],
+    ) -> Self {
+        let Some(fp) = first_person else {
+            return Self::default();
+        };
+        Self(
+            fp.mesh_annotations
+                .iter()
+                .filter_map(|a| {
+                    let node = node_assets.get(nodes.get(a.node)?)?;
+                    Some((Name::new(node.name.clone()), a.first_person_flag))
+                })
+                .collect(),
+        )
+    }
+}
+
+/// Render layers used to separate first-person-only and third-person-only meshes.
+#[derive(Resource, Clone)]
+pub struct FirstPersonLayers {
+    pub first_person_only: Layer,
+    pub third_person_only: Layer,
+}
+
+impl Default for FirstPersonLayers {
+    fn default() -> Self {
+        Self {
+            first_person_only: 7,
+            third_person_only: 8,
+        }
+    }
+}
+
+/// Attach to a camera that renders from the avatar's point of view.
+#[derive(Component, Debug, Copy, Clone, Reflect)]
+#[reflect(Component)]
+pub struct FirstPersonCamera;
+
+/// Attach to a camera that observes the avatar from outside.
+#[derive(Component, Debug, Copy, Clone, Reflect)]
+#[reflect(Component)]
+pub struct ThirdPersonCamera;
+
+fn setup_first_person_camera(
+    trigger: On<Add, FirstPersonCamera>,
+    mut commands: Commands,
+    layers: Res<FirstPersonLayers>,
+) {
+    commands
+        .entity(trigger.entity)
+        .insert(RenderLayers::default().with(layers.first_person_only));
+}
+
+fn setup_third_person_camera(
+    trigger: On<Add, ThirdPersonCamera>,
+    mut commands: Commands,
+    layers: Res<FirstPersonLayers>,
+) {
+    commands
+        .entity(trigger.entity)
+        .insert(RenderLayers::default().with(layers.third_person_only));
+}
+
+/// Applies first-person render layers to all meshes of the target VRM.
+///
+/// ```no_run
+/// # use bevy::prelude::*;
+/// # use bevy_vrm1::prelude::*;
+/// fn enable(mut commands: Commands, vrm: Entity) {
+///     commands.entity(vrm).trigger(RequestEnableFirstPerson);
+/// }
+/// ```
+#[derive(EntityEvent)]
+pub struct RequestEnableFirstPerson(pub Entity);
+
+/// Makes all meshes of the target VRM visible to all cameras again.
+#[derive(EntityEvent)]
+pub struct RequestDisableFirstPerson(pub Entity);
+
+/// A mesh entity waiting for the `auto` head split.
+#[derive(Component)]
+pub(crate) struct PendingAutoSplit;
+
+/// Attached to the original mesh entity after the `auto` split.
+#[derive(Component)]
+pub(crate) struct AutoSplitDone {
+    head_entity: Entity,
+}
+
+fn apply_enable_first_person(
+    trigger: On<RequestEnableFirstPerson>,
+    mut commands: Commands,
+    registries: Query<&FirstPersonRegistry>,
+    searcher: ChildSearcher,
+    layers: Res<FirstPersonLayers>,
+    children: Query<&Children>,
+    meshes: Query<(), With<Mesh3d>>,
+) {
+    let vrm = trigger.event_target();
+    let Ok(registry) = registries.get(vrm) else {
+        return;
+    };
+
+    // Mesh entities already covered by an explicit annotation.
+    let mut covered = HashSet::new();
+    for (name, flag) in registry.iter() {
+        let Some(node) = searcher.find_from_name(vrm, name.as_str()) else {
+            continue;
+        };
+        for mesh_entity in descendants_with_mesh(node, &children, &meshes) {
+            covered.insert(mesh_entity);
+            apply_flag(&mut commands, mesh_entity, *flag, &layers);
+        }
+    }
+
+    // Per spec: meshes without an annotation are treated as `auto`.
+    for mesh_entity in descendants_with_mesh(vrm, &children, &meshes) {
+        if !covered.contains(&mesh_entity) {
+            apply_flag(&mut commands, mesh_entity, FirstPersonFlag::Auto, &layers);
+        }
+    }
+}
+
+fn apply_disable_first_person(
+    trigger: On<RequestDisableFirstPerson>,
+    mut commands: Commands,
+    children: Query<&Children>,
+    meshes: Query<(), With<Mesh3d>>,
+) {
+    let vrm = trigger.event_target();
+    for mesh_entity in descendants_with_mesh(vrm, &children, &meshes) {
+        commands
+            .entity(mesh_entity)
+            .insert(RenderLayers::default())
+            .remove::<PendingAutoSplit>();
+    }
+}
+
+fn apply_flag(
+    commands: &mut Commands,
+    mesh_entity: Entity,
+    flag: FirstPersonFlag,
+    layers: &FirstPersonLayers,
+) {
+    match flag {
+        FirstPersonFlag::Both => {
+            commands.entity(mesh_entity).insert(RenderLayers::default());
+        }
+        FirstPersonFlag::ThirdPersonOnly => {
+            commands
+                .entity(mesh_entity)
+                .insert(RenderLayers::layer(layers.third_person_only));
+        }
+        FirstPersonFlag::FirstPersonOnly => {
+            commands
+                .entity(mesh_entity)
+                .insert(RenderLayers::layer(layers.first_person_only));
+        }
+        FirstPersonFlag::Auto => {
+            commands.entity(mesh_entity).insert(PendingAutoSplit);
+        }
+    }
+}
+
+fn split_auto_meshes(
+    mut commands: Commands,
+    mut mesh_assets: ResMut<Assets<Mesh>>,
+    already_split: Query<(Entity, &AutoSplitDone), With<PendingAutoSplit>>,
+    unskinned: Query<
+        Entity,
+        (
+            With<PendingAutoSplit>,
+            Without<SkinnedMesh>,
+            Without<AutoSplitDone>,
+        ),
+    >,
+    pending: Query<
+        (
+            Entity,
+            &Mesh3d,
+            &SkinnedMesh,
+            &ChildOf,
+            Option<&MeshMaterial3d<MToonMaterial>>,
+            Option<&MeshMorphWeights>,
+            Option<&Name>,
+        ),
+        (With<PendingAutoSplit>, Without<AutoSplitDone>),
+    >,
+    parents: Query<&ChildOf>,
+    vrms: Query<&HeadBoneEntity, With<Vrm>>,
+    children: Query<&Children>,
+    layers: Res<FirstPersonLayers>,
+) {
+    // Re-enabling after a previous split: just restore the layers.
+    for (entity, done) in already_split.iter() {
+        commands
+            .entity(entity)
+            .insert(RenderLayers::default())
+            .remove::<PendingAutoSplit>();
+        commands
+            .entity(done.head_entity)
+            .insert(RenderLayers::layer(layers.third_person_only));
+    }
+
+    // Meshes without a skin cannot be weighted to the head bone: treat as `both`.
+    for entity in unskinned.iter() {
+        commands
+            .entity(entity)
+            .insert(RenderLayers::default())
+            .remove::<PendingAutoSplit>();
+    }
+
+    for (entity, mesh3d, skinned, child_of, material, morph_weights, name) in pending.iter() {
+        // The VRM root is the ancestor holding `Vrm` + `HeadBoneEntity`.
+        // It may not be initialized yet; retry on the next frame.
+        let Some(head) = find_head_bone(entity, &parents, &vrms) else {
+            continue;
+        };
+
+        // The head bone and all of its descendants.
+        let mut head_set = HashSet::new();
+        collect_descendants(head, &children, &mut head_set);
+
+        // Joint indices of this skin that point into the head subtree.
+        let head_joint_ids = skinned
+            .joints
+            .iter()
+            .enumerate()
+            .filter(|(_, joint)| head_set.contains(*joint))
+            .map(|(index, _)| index as u16)
+            .collect::<HashSet<u16>>();
+
+        // The mesh asset may not be loaded yet; retry on the next frame.
+        let Some(mesh) = mesh_assets.get(&mesh3d.0) else {
+            continue;
+        };
+        match classify_auto_mesh(mesh, &head_joint_ids) {
+            // Nothing is weighted to the head: keep visible everywhere.
+            AutoSplit::Both => {
+                commands
+                    .entity(entity)
+                    .insert(RenderLayers::default())
+                    .remove::<PendingAutoSplit>();
+            }
+            // The whole mesh belongs to the head (face, eyes, hair):
+            // hide it from first-person cameras, no split needed.
+            AutoSplit::ThirdPersonOnly => {
+                commands
+                    .entity(entity)
+                    .insert(RenderLayers::layer(layers.third_person_only))
+                    .remove::<PendingAutoSplit>();
+            }
+            // Mixed weights: split into a head part and the rest.
+            AutoSplit::Split(parts) => {
+                let (head_mesh, rest_mesh) = *parts;
+                let head_handle = mesh_assets.add(head_mesh);
+                let rest_handle = mesh_assets.add(rest_mesh);
+
+                // The head part is a new sibling entity under the same glTF node,
+                // visible only to third-person cameras.
+                let head_name = name.map(Name::as_str).unwrap_or("mesh");
+                let mut head_commands = commands.spawn((
+                    Name::new(format!("{head_name}.headSplit")),
+                    ChildOf(child_of.parent()),
+                    Mesh3d(head_handle),
+                    skinned.clone(),
+                    RenderLayers::layer(layers.third_person_only),
+                ));
+                if let Some(material) = material {
+                    head_commands.insert(material.clone());
+                }
+                if let Some(morph_weights) = morph_weights {
+                    head_commands.insert(morph_weights.clone());
+                }
+                let head_entity = head_commands.id();
+
+                // The original entity keeps only the non-head part and stays visible everywhere.
+                commands
+                    .entity(entity)
+                    .insert((
+                        Mesh3d(rest_handle),
+                        RenderLayers::default(),
+                        AutoSplitDone { head_entity },
+                    ))
+                    .remove::<PendingAutoSplit>();
+            }
+        }
+    }
+}
+
+/// Walks up the hierarchy to the VRM root and returns its head bone entity.
+fn find_head_bone(
+    mesh_entity: Entity,
+    parents: &Query<&ChildOf>,
+    vrms: &Query<&HeadBoneEntity, With<Vrm>>,
+) -> Option<Entity> {
+    let mut current = mesh_entity;
+    loop {
+        if let Ok(head) = vrms.get(current) {
+            return Some(head.0);
+        }
+        current = parents.get(current).ok()?.parent();
+    }
+}
+
+fn collect_descendants(
+    entity: Entity,
+    children: &Query<&Children>,
+    output: &mut HashSet<Entity>,
+) {
+    output.insert(entity);
+    if let Ok(entity_children) = children.get(entity) {
+        for child in entity_children {
+            collect_descendants(*child, children, output);
+        }
+    }
+}
+
+/// Returns `root` and all of its descendants that have a `Mesh3d`.
+fn descendants_with_mesh(
+    root: Entity,
+    children: &Query<&Children>,
+    meshes: &Query<(), With<Mesh3d>>,
+) -> Vec<Entity> {
+    let mut found = Vec::new();
+    let mut stack = vec![root];
+    while let Some(entity) = stack.pop() {
+        if meshes.contains(entity) {
+            found.push(entity);
+        }
+        if let Ok(entity_children) = children.get(entity) {
+            stack.extend(entity_children.iter().copied());
+        }
+    }
+    found
+}
+
+/// Classification of an `auto` mesh relative to the head bone subtree.
+enum AutoSplit {
+    /// No triangles are weighted to the head: visible everywhere.
+    Both,
+    /// Every triangle is weighted to the head (face, eyes, hair):
+    /// the whole mesh must be hidden from first-person cameras.
+    ThirdPersonOnly,
+    /// Mixed weights: (head part, rest part), split by triangle, index-only.
+    Split(Box<(Mesh, Mesh)>),
+}
+
+fn classify_auto_mesh(
+    mesh: &Mesh,
+    head_joint_ids: &HashSet<u16>,
+) -> AutoSplit {
+    use bevy::mesh::VertexAttributeValues;
+
+    if head_joint_ids.is_empty() {
+        return AutoSplit::Both;
+    }
+    let Some(VertexAttributeValues::Uint16x4(joint_indices)) =
+        mesh.attribute(Mesh::ATTRIBUTE_JOINT_INDEX)
+    else {
+        return AutoSplit::Both;
+    };
+    let Some(VertexAttributeValues::Float32x4(joint_weights)) =
+        mesh.attribute(Mesh::ATTRIBUTE_JOINT_WEIGHT)
+    else {
+        return AutoSplit::Both;
+    };
+
+    let is_head_vertex: Vec<bool> = joint_indices
+        .iter()
+        .zip(joint_weights)
+        .map(|(idx, w)| (0..4).any(|k| w[k] > 0.0 && head_joint_ids.contains(&idx[k])))
+        .collect();
+
+    let Some(indices) = mesh.indices() else {
+        return AutoSplit::Both;
+    };
+    let indices: Vec<u32> = indices.iter().map(|i| i as u32).collect();
+    let (mut head, mut rest) = (Vec::new(), Vec::new());
+    for tri in indices.chunks_exact(3) {
+        let target = if tri.iter().any(|&v| is_head_vertex[v as usize]) {
+            &mut head
+        } else {
+            &mut rest
+        };
+        target.extend_from_slice(tri);
+    }
+
+    match (head.is_empty(), rest.is_empty()) {
+        (true, _) => AutoSplit::Both,
+        (false, true) => AutoSplit::ThirdPersonOnly,
+        (false, false) => {
+            let mut head_mesh = mesh.clone();
+            head_mesh.insert_indices(Indices::U32(head));
+            let mut rest_mesh = mesh.clone();
+            rest_mesh.insert_indices(Indices::U32(rest));
+            AutoSplit::Split(Box::new((head_mesh, rest_mesh)))
+        }
+    }
+}

--- a/src/vrm/gltf/extensions/vrmc_vrm.rs
+++ b/src/vrm/gltf/extensions/vrmc_vrm.rs
@@ -6,8 +6,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize)]
 pub struct VrmcVrm {
     pub expressions: Option<Expressions>,
-    // #[serde(rename = "firstPerson")]
-    // pub first_person: Option<FirstPerson>,
+    #[serde(rename = "firstPerson", default)]
+    pub first_person: Option<FirstPerson>,
     pub humanoid: Humanoid,
     #[serde(rename = "lookAt")]
     pub look_at: Option<LookAtProperties>,
@@ -49,17 +49,27 @@ pub struct Humanoid {
     pub human_bones: HashMap<String, VrmNode>,
 }
 
-#[derive(Serialize, Deserialize)]
-pub struct Struct6 {
-    pub node: i64,
-    #[serde(rename = "type")]
-    pub r#type: String,
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Default, Reflect)]
+#[serde(rename_all = "camelCase")]
+pub enum FirstPersonFlag {
+    #[default]
+    Auto,
+    Both,
+    ThirdPersonOnly,
+    FirstPersonOnly,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+pub struct MeshAnnotation {
+    pub node: usize,
+    #[serde(rename = "firstPersonFlag", default)]
+    pub first_person_flag: FirstPersonFlag,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct FirstPerson {
-    #[serde(rename = "meshAnnotations")]
-    pub mesh_annotations: Vec<Struct6>,
+    #[serde(rename = "meshAnnotations", default)]
+    pub mesh_annotations: Vec<MeshAnnotation>,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/src/vrm/initialize.rs
+++ b/src/vrm/initialize.rs
@@ -1,6 +1,7 @@
 use crate::error::vrm_error;
 use crate::prelude::ChildSearcher;
 use crate::vrm::expressions::{RequestInitializeExpressions, VrmExpressionRegistry};
+use crate::vrm::first_person::FirstPersonRegistry;
 use crate::vrm::gltf::extensions::VrmExtensions;
 use crate::vrm::humanoid_bone::{HumanoidBoneRegistry, RequestInitializeHumanoidBones};
 use crate::vrm::loader::{VrmAsset, VrmHandle};
@@ -79,6 +80,11 @@ fn spawn_vrm(
                 &vrm.gltf.nodes,
             ),
             NodeConstraintRegistry::new(&vrm.gltf, &node_assets),
+            FirstPersonRegistry::new(
+                extensions.vrmc_vrm.first_person.as_ref(),
+                &node_assets,
+                &vrm.gltf.nodes,
+            ),
         ));
 
         if let Some(spring_bone) = extensions.vrmc_spring_bone.as_ref() {


### PR DESCRIPTION
Closes #6

## What
- Implements `VRMC_vrm.firstPerson` mesh visibility (`both` / `thirdPersonOnly` / `firstPersonOnly` / `auto`) using `RenderLayers`.
- `auto` meshes are classified against the head bone's skin weights: fully-head meshes (face/eyes/hair) go straight to `thirdPersonOnly`, mixed meshes are split into a head part and a body part, unweighted meshes stay `both`.
- Adds `RequestEnableFirstPerson` / `RequestDisableFirstPerson` events, `FirstPersonCamera` / `ThirdPersonCamera` marker components, and `FirstPersonLayers` resource.
- Adds `examples/first_person.rs` demonstrating a toggleable first-person camera plus a picture-in-picture first-person viewport.

## Testing
- `cargo test`, `cargo clippy --all-targets -- -D warnings` pass locally.
- Manually verified with AliciaSolid.vrm: pressing `F` moves the main camera into the head bone and hides face/eyes/hair; the PiP camera shows the first-person view continuously.