### PR TITLE
fix: preserve spring bone direction when point transforms cancel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Bug Fixes
+
+- Fixed spring-bone chains disappearing when an inverse point transform rounded a very short tail direction to zero
+
 ## v0.9.0
 
 ### Features

--- a/src/vrm/spring_bone/update.rs
+++ b/src/vrm/spring_bone/update.rs
@@ -2,7 +2,7 @@ use crate::system_set::VrmSystemSets;
 use crate::vrm::gltf::extensions::vrmc_spring_bone::ColliderShape;
 use crate::vrm::spring_bone::{SpringJointProps, SpringJointState, SpringRoot};
 use bevy::app::App;
-use bevy::math::Vec3;
+use bevy::math::{Mat4, Vec3};
 use bevy::prelude::*;
 use bevy::time::Time;
 
@@ -75,20 +75,43 @@ fn update_spring_bones(
             state.prev_tail = state.current_tail;
             state.current_tail = global_to_center_local(next_tail, &center_gtf);
 
-            let to = (parent_gtf.to_matrix() * state.initial_local_matrix)
-                .inverse()
-                .transform_point3(next_tail)
-                .normalize();
+            let initial_global_matrix = parent_gtf.to_matrix() * state.initial_local_matrix;
 
             let Ok((mut tf, mut gtf)) = transforms.get_mut(joint) else {
                 continue;
             };
 
-            tf.rotation =
-                state.initial_local_rotation * Quat::from_rotation_arc(state.bone_axis, to);
+            let delta_rotation =
+                tail_rotation_or_identity(state.bone_axis, initial_global_matrix, next_tail);
+            tf.rotation = state.initial_local_rotation * delta_rotation;
             *gtf = parent_gtf.mul_transform(*tf);
         }
     }
+}
+
+fn tail_rotation_or_identity(
+    from: Vec3,
+    initial_global_matrix: Mat4,
+    tail_global_pos: Vec3,
+) -> Quat {
+    let inverse = initial_global_matrix.inverse();
+    let to = inverse.transform_point3(tail_global_pos);
+    if let Some(to) = to.try_normalize() {
+        Quat::from_rotation_arc(from, to)
+    } else {
+        let initial_head_global_pos = initial_global_matrix.transform_point3(Vec3::ZERO);
+        let to = inverse.transform_vector3(tail_global_pos - initial_head_global_pos);
+        rotation_arc_or_identity(from, to)
+    }
+}
+
+fn rotation_arc_or_identity(
+    from: Vec3,
+    to: Vec3,
+) -> Quat {
+    to.try_normalize()
+        .map(|to| Quat::from_rotation_arc(from, to))
+        .unwrap_or(Quat::IDENTITY)
 }
 
 fn center_local_to_global(
@@ -131,6 +154,75 @@ fn apply_collision(
             head_global_pos,
             joint_radius,
             bone_length,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tail_rotation_matches_previous_behavior_for_finite_direction() {
+        let from = Vec3::new(1.0, 2.0, 3.0).normalize();
+        let matrix = Mat4::from_scale_rotation_translation(
+            Vec3::new(0.75, 1.25, 0.5),
+            Quat::from_euler(EulerRot::XYZ, 0.2, -0.3, 0.4),
+            Vec3::new(-1.0, 2.0, 3.0),
+        );
+        let tail = matrix.transform_point3(Vec3::new(-4.0, 5.0, 6.0));
+
+        let actual = tail_rotation_or_identity(from, matrix, tail);
+        let previous =
+            Quat::from_rotation_arc(from, matrix.inverse().transform_point3(tail).normalize());
+
+        assert_eq!(actual, previous);
+    }
+
+    #[test]
+    fn tail_rotation_falls_back_when_point_transform_cancels_out() {
+        let matrix = Mat4::from_cols_array(&[
+            0.35692674,
+            -0.6559648,
+            -0.06937952,
+            0.0,
+            1.0731882,
+            0.60601205,
+            -0.20860665,
+            0.0,
+            0.0954045,
+            3.7252903e-9,
+            0.49081358,
+            0.0,
+            -0.09683231,
+            1.3288133,
+            0.070472986,
+            1.0,
+        ]);
+        let head = matrix.transform_point3(Vec3::ZERO);
+        let tail = Vec3::new(-0.0968323, 1.3288133, 0.070473);
+        let inverse = matrix.inverse();
+        let via_point = inverse.transform_point3(tail);
+        let via_vector = inverse.transform_vector3(tail - head);
+
+        let actual = tail_rotation_or_identity(Vec3::Y, matrix, tail);
+        let expected = Quat::from_rotation_arc(Vec3::Y, via_vector.normalize());
+
+        assert_eq!(via_point, Vec3::ZERO);
+        assert_ne!(via_vector, Vec3::ZERO);
+        assert!(actual.is_finite());
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn rotation_arc_is_identity_for_zero_direction() {
+        assert_eq!(
+            rotation_arc_or_identity(Vec3::Y, Vec3::ZERO),
+            Quat::IDENTITY
+        );
+        assert_eq!(
+            tail_rotation_or_identity(Vec3::Y, Mat4::IDENTITY, Vec3::ZERO),
+            Quat::IDENTITY
         );
     }
 }


### PR DESCRIPTION
## Summary

- Prevent non-finite spring-bone rotations when an inverse point transform rounds a very short, valid tail direction to zero.
- Preserve the existing point-transform path for normal inputs and use the mathematically equivalent vector transform only as a fallback.
- Add regression tests and an `Unreleased` changelog entry.

## Root cause

The spring-bone update transformed the next tail position into the joint's initial local space and normalized it unconditionally.

With the official Seed-san sample model, the `hair_F.001` joint has a very short but valid head-to-tail distance (approximately `1.7371057e-7`). In `f32`, the inverse point transform can cancel to exactly `Vec3::ZERO`, while transforming the corresponding head-to-tail vector through the same inverse matrix remains finite. Normalizing the zero result produces a non-finite rotation, which makes the affected hair section disappear on some frames.

## Implementation

The existing inverse point transform is still used whenever it produces a normalizable direction. Only when that normalization fails, the code:

1. obtains the initial joint origin from the same initial global matrix;
2. transforms the global head-to-tail difference as a vector through the same inverse matrix; and
3. uses an identity delta rotation only if no valid direction exists.

This introduces no model-specific branch or epsilon threshold. It does not change the public API, system ordering, or the numerical path for normal inputs.

Relevant specification: [VRMC_springBone-1.0](https://github.com/vrm-c/vrm-specification/blob/master/specification/VRMC_springBone-1.0/README.md)

## Validation

- `cargo fmt --all -- --check`
- `cargo test`: 53 unit tests and 10 doc tests passed on macOS
- `cargo test --doc --all-features`: 10 doc tests passed
- `cargo clippy --workspace --all-targets --all-features -- -Dwarnings`
- `cargo clippy --workspace --all-targets -- -Dwarnings`
- Linux x86_64 under QEMU: `cargo test --locked --offline --lib` passed 53/53 tests, including the exact point-cancellation regression
- Controlled render comparison across 20 VRM models and 10 frames each:
  - 199/200 WebP outputs were byte-identical to the original implementation
  - the only changed output was the affected Seed-san frame, where the missing hair was restored
  - no panic, error, NaN, or non-finite-value diagnostics were observed
