### PR TITLE
fix: allow omitted VRMC_springBone collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Bug Fixes
+
+- Allowed `VRMC_springBone` to omit the optional `colliders`, `colliderGroups`, and `springs` arrays, defaulting them to empty collections as specified
+
 ## v0.9.1
 
 [Release Notes](https://github.com/not-elm/bevy_vrm1/releases/tag/v0.9.1)

--- a/src/vrm/gltf/extensions/vrmc_spring_bone.rs
+++ b/src/vrm/gltf/extensions/vrmc_spring_bone.rs
@@ -8,13 +8,15 @@ pub struct VRMCSpringBone {
     pub spec_version: String,
 
     /// [Collider]
+    #[serde(default)]
     pub colliders: Vec<Collider>,
 
     /// [`ColliderGroup`]
-    #[serde(rename = "colliderGroups")]
+    #[serde(rename = "colliderGroups", default)]
     pub collider_groups: Vec<ColliderGroup>,
 
     /// [Spring]
+    #[serde(default)]
     pub springs: Vec<Spring>,
 }
 
@@ -173,5 +175,27 @@ mod tests {
         let _spring_bone: VRMCSpringBone =
             serde_json::from_str(include_str!("vrmc_spring_bone.json"))?;
         success!()
+    }
+
+    #[test]
+    fn deserialize_vrmc_spring_bone_without_optional_collections() -> TestResult {
+        let spring_bone: VRMCSpringBone = serde_json::from_str(r#"{"specVersion":"1.0"}"#)?;
+
+        assert!(spring_bone.colliders.is_empty());
+        assert!(spring_bone.collider_groups.is_empty());
+        assert!(spring_bone.springs.is_empty());
+        success!()
+    }
+
+    #[test]
+    fn reject_invalid_vrmc_spring_bone_collections() {
+        for invalid in [
+            "{}",
+            r#"{"specVersion":"1.0","colliders":null}"#,
+            r#"{"specVersion":"1.0","colliderGroups":null}"#,
+            r#"{"specVersion":"1.0","springs":null}"#,
+        ] {
+            assert!(serde_json::from_str::<VRMCSpringBone>(invalid).is_err());
+        }
     }
 }


### PR DESCRIPTION
## Summary

- allow `VRMC_springBone` to omit the optional `colliders`, `colliderGroups`, and `springs` properties
- deserialize omitted collections as empty vectors while keeping `specVersion` required
- continue rejecting explicit `null` collection values and add regression coverage

## Why

The VRMC_springBone 1.0 schema requires only `specVersion`; the three collection properties are optional. The current Rust fields use `Vec<T>` without Serde defaults, which makes those properties mandatory during deserialization. As a result, a valid file that omits an empty collection cannot load its spring-bone extension.

This addresses one independent strict-deserialization item discussed in #64.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --all-targets` (55 tests passed)
- `cargo clippy --all-targets --all-features -- -D warnings`
